### PR TITLE
Rename plugin from humanmade/hm-media-weight to humanmade/media-weight

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ Ideally, it will eventually make accurate estimations of aggregate page size bas
 Download this plugin, activate it within WordPress, and run the Node build. In Altis, this can be done via the following commands (run them from a terminal in the project `content/plugins/` directory):
 
 ```
-git clone git@github.com:humanmade/hm-media-weight.git
-composer server cli -- plugin activate hm-media-weight
-cd hm-media-weight
+git clone git@github.com:humanmade/media-weight.git
+composer server cli -- plugin activate media-weight
+cd media-weight
 nvm use
 npm install
 npm run build

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "humanmade/hm-media-weight",
+	"name": "humanmade/media-weight",
 	"description": "Block Editor plugin to monitor media bandwidth usage.",
 	"type": "wordpress-plugin",
 	"homepage": "https://humanmade.com",

--- a/media-weight.php
+++ b/media-weight.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name:       HM Media Weight
- * Description:       Block Editor plugin to monitor media bandwidth usage.
+ * Description:       Block Editor plugin to monitor approximate media bandwidth usage on a post.
  * Requires PHP:      8.1
  * Version:           0.1.0
  * Author:            Human Made Ltd

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-	"name": "hm-media-weight",
-	"version": "0.1.0",
+	"name": "media-weight",
+	"private": true,
 	"description": "Block Editor plugin to monitor media bandwidth usage.",
 	"author": "Human Made Limited",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
Reduces unnecessary prefixing on composer package and repo name

This is not yet published to Composer, so nothing else needs to change externally until we pull the updated code into a project.