### PR TITLE
Read actual GET response length if reading content-length off HEAD fails

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,12 @@
 {
+	"root": true,
 	"extends": [ "plugin:@wordpress/eslint-plugin/recommended" ],
+	"parserOptions": {
+		"requireConfigFile": false,
+		"babelOptions": {
+			"presets": [ "@wordpress/babel-preset-default" ]
+		}
+	},
 	"env": {
 		"browser": true
 	},

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Currently, all this plugin does is to register a block editor plugin sidebar whi
 
 The sidebar will list the attachment's ID and type with its filesize in megabytes, the URI for the image, a `<details>` tab that can be expanded to view the attachment's entity record as formatted JSON, and a button to select and jump to that block in the editor.
 
-Ideally, it will eventually make accurate estimations of aggregate page size based on the associated media, and display a pre-publish or editor-banner warning when that size goes above a specific threshold.
+File size is calculated based on the retrieved image size (measured off HEAD request `content-length`, or the string length of a GET response body if the HEAD did not return a content length value) for the size of image which is selected in an image block. Image sizes are read off of actual remote image requests for PHP, which are dispatched from a cron job that gets scheduled as soon as an API request is made for a post which has image or video blocks.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,20 @@ The sidebar will list the attachment's ID and type with its filesize in megabyte
 
 File size is calculated based on the retrieved image size (measured off HEAD request `content-length`, or the string length of a GET response body if the HEAD did not return a content length value) for the size of image which is selected in an image block. Image sizes are read off of actual remote image requests for PHP, which are dispatched from a cron job that gets scheduled as soon as an API request is made for a post which has image or video blocks.
 
+## Hooks
+
+### `hm_media_weight_threshold`
+
+Sets the threshold at which a post is deemed "too heavy" due to media weight.
+
+Filter function will receive one `float` argument: the `$threshold`, or maximum number of megabytes of media permitted per post.
+
+### `hm_media_weight_featured_image_size_slug`
+
+Determines the expected image size slug for a desktop featured image.
+
+The filter function receives one `string` argument: the `$size_slug`, defining the string name of the image size which is expected to be used for a desktop featured image.
+
 ## Development
 
 Download this plugin, activate it within WordPress, and run the Node build. In Altis, this can be done via the following commands (run them from a terminal in the project `content/plugins/` directory):

--- a/README.md
+++ b/README.md
@@ -18,11 +18,36 @@ Sets the threshold at which a post is deemed "too heavy" due to media weight.
 
 Filter function will receive one `float` argument: the `$threshold`, or maximum number of megabytes of media permitted per post.
 
+Example:
+
+```php
+add_filter(
+	'hm_media_weight_threshold',
+	function( float $threshold ) {
+		// We want to be very aggressive about image weight,
+		// warn if more than 500kb of media on a post.
+		return 0.5;
+	}
+);
+```
+
 ### `hm_media_weight_featured_image_size_slug`
 
 Determines the expected image size slug for a desktop featured image.
 
 The filter function receives one `string` argument: the `$size_slug`, defining the string name of the image size which is expected to be used for a desktop featured image.
+
+Example:
+
+```php
+add_filter(
+	'hm_media_weight_featured_image_size_slug',
+	function( string $size_slug ) : string {
+		// Our classic theme uses this size image in its single.php template.
+		return 'article-16x9';
+	}
+);
+```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,25 @@ add_filter(
 );
 ```
 
+### `hm_media_weight_calculated_sizes`
+
+Allows a site to skip processing image sizes which are not expected to be used in post content. **Note** however that this can result in the full, uncompressed image size being shown as the expected post weight if a non-standard image crop is selected in the editor.
+
+The filter function receives one `string[]` argument: the `$calculated_image_sizes` list returned from `get_intermediate_image_sizes()`, which can be filtered as required by your specific application to restrict size checks to only certain image size slugs.
+
+Example:
+
+```php
+add_filter(
+	'hm_media_weight_calculated_sizes',
+	function( array $image_sizes ) : array {
+		// Our site will only ever use "large" or "hero-wide" images,
+		// skip calculating other sizes.
+		return [ 'large', 'article-16x9' ];
+	}
+);
+```
+
 ## Development
 
 Download this plugin, activate it within WordPress, and run the Node build. In Altis, this can be done via the following commands (run them from a terminal in the project `content/plugins/` directory):

--- a/inc/assets.php
+++ b/inc/assets.php
@@ -55,7 +55,9 @@ function register_block_plugin_editor_scripts() {
 			 */
 			'mediaThreshold' => apply_filters( 'hm_media_weight_threshold', 2.50 ),
 			/**
-			 * Filter the expected maximum width (in pixels) for a desktop featured image.
+			 * Filter the expected image size slug for a desktop featured image.
+			 *
+			 * @param string $size_slug String name of image size used for desktop featured image.
 			 */
 			'featuredImageSize' => apply_filters( 'hm_media_weight_featured_image_size_slug', 'large' ),
 		]

--- a/inc/assets.php
+++ b/inc/assets.php
@@ -51,7 +51,7 @@ function register_block_plugin_editor_scripts() {
 			/**
 			 * Filter the threshold at which a post is deemed "too heavy" due to media weight.
 			 *
-			 * @param float $threshold Maxmimum number of megabytes of media permitted per post.
+			 * @param float $threshold Maximum number of megabytes of media permitted per post.
 			 */
 			'mediaThreshold' => apply_filters( 'hm_media_weight_threshold', 2.50 ),
 			/**

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -59,10 +59,20 @@ function schedule_file_size_check( $attachment_id ) {
 /**
  * Logs the file sizes for each image size of the uploaded attachment.
  *
+ * Image weights are retrieved via remote request against the image's URI.
+ *
  * @param int $attachment_id The ID of the uploaded attachment.
  */
 function store_intermediate_file_sizes( $attachment_id ) {
-	$image_sizes = get_intermediate_image_sizes();
+	/**
+	 * Filter which size slugs we retrieve image size information for.
+	 *
+	 * Enables a site from skipping computation (remote request) for any size
+	 * slugs that are explicitly not expected/allowed to be used in posts.
+	 *
+	 * @param string[] $calculated_image_sizes Maximum number of megabytes of media permitted per post.
+	 */
+	$image_sizes = apply_filters( 'hm_media_weight_calculated_sizes', get_intermediate_image_sizes() );
 	$file_sizes  = [];
 
 	foreach ( $image_sizes as $size ) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,12 @@
 import { useMemo } from 'react';
 import { __, sprintf } from '@wordpress/i18n';
 import { PluginSidebar, PluginSidebarMoreMenuItem } from '@wordpress/editor';
-import { PanelRow, PanelBody, Button } from '@wordpress/components';
+import { PanelRow, PanelBody, Button, FlexItem, Flex } from '@wordpress/components';
 import { registerPlugin, unregisterPlugin } from '@wordpress/plugins';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { useEntityRecords } from '@wordpress/core-data';
+import { Icon, caution } from '@wordpress/icons';
 
 import { ReactComponent as ScalesIcon } from './assets/scale-icon.svg';
 
@@ -162,8 +163,9 @@ const HMMediaWeightSidebar = () => {
 		}
 		let mediaSize = attachment.media_details.filesize;
 
+		let requestedSize = '';
 		if ( attachment.media_type === 'image' ) {
-			const requestedSize = attachment.id !== featuredImageId
+			requestedSize = attachment.id !== featuredImageId
 				? mediaBlocks.find( ( block ) => block.clientId === associatedBlockClientId )?.attributes?.sizeSlug
 				: ( featuredImageSize || 'full' );
 			// Swap in the actual measured size of the target image, if available.
@@ -182,7 +184,8 @@ const HMMediaWeightSidebar = () => {
 			thumbnail,
 			type,
 			mediaSize,
-			blockButton
+			blockButton,
+			requestedSize,
 		};
 	} );
 
@@ -196,8 +199,22 @@ const HMMediaWeightSidebar = () => {
 					initialOpen={ true }
 					title={ __( 'Total Media Items', 'hm-media-weight' ) }
 				>
-					<p>Images: { imageCount }</p>
-					<p>Videos: { videoCount }</p>
+					<p>{ imageCount
+						? sprintf(
+							/* translators: %d: Number of WP-hosted images in post. */
+							__( 'Images: %d', 'hm-media-weight' ),
+							imageCount
+						)
+						: __( 'No images', 'hm-media-weight' )
+					}</p>
+					<p>{ videoCount
+						? sprintf(
+							/* translators: %d: Number of WP-hosted videos in post. */
+							__( 'Videos: %d', 'hm-media-weight' ),
+							videoCount
+						)
+						: __( 'No videos', 'hm-media-weight' )
+					}</p>
 
 					<DisplayTotal
 						imageCount={ imageCount }
@@ -211,7 +228,7 @@ const HMMediaWeightSidebar = () => {
 					initialOpen={ false }
 					title={ __( 'Individual Media Items', 'hm-media-weight' ) }
 				>
-					{ attachmentSizeDetails.map( ( { attachment, thumbnail, type, mediaSize, blockButton } ) => {
+					{ attachmentSizeDetails.map( ( { attachment, thumbnail, type, mediaSize, blockButton, requestedSize } ) => {
 
 						return (
 							<PanelRow key={ `media-details-${ attachment.id }` }>
@@ -223,6 +240,7 @@ const HMMediaWeightSidebar = () => {
 											style={ { maxWidth: '100%' } }
 										/>
 									) : null }
+
 									<p>
 										<strong>
 											{ type }: {
@@ -232,10 +250,25 @@ const HMMediaWeightSidebar = () => {
 											}
 										</strong>
 									</p>
+
 									<p>
 										Attachment ID: { attachment.id }<br />
 										<small><a href={ `upload.php?item=${ attachment.id }` }>Go to the attachment post &rsaquo;</a></small>
 									</p>
+
+									{ requestedSize === 'full' && (
+										<>
+											<Flex direction="row" gap={ 6 }>
+												<FlexItem>
+													<Icon icon={ caution } size={ 36 } />
+												</FlexItem>
+												<FlexItem>
+													<p><strong>{ __( 'Full size image requested. Edit block to request smaller image.', 'hm-media-weight' ) }</strong></p>
+												</FlexItem>
+											</Flex>
+										</>
+									) }
+
 									<details style={ { display: 'none', margin: '0.5rem 0 1rem' } }>
 										<summary>{ __( 'View entity record JSON', 'hm-media-weight' ) }</summary>
 										<small>

--- a/src/index.js
+++ b/src/index.js
@@ -263,7 +263,7 @@ const HMMediaWeightSidebar = () => {
 
 									{ requestedSize === 'full' && (
 										<>
-											<Flex direction="row" gap={ 6 }>
+											<Flex direction="row" align="flex-start" gap={ 6 }>
 												<FlexItem>
 													<Icon icon={ caution } size={ 36 } />
 												</FlexItem>

--- a/src/index.js
+++ b/src/index.js
@@ -89,7 +89,7 @@ const HMMediaWeightSidebar = () => {
 	let videosSize = 0;
 
 	// eslint-disable-next-line no-shadow
-	const DisplayTotal = ( { imagesSize, videosSize } ) => {
+	const DisplayTotal = ( { imageCount, imagesSize, videoCount, videosSize } ) => {
 		const total = ( ( imagesSize + videosSize ) / MB_IN_B ).toFixed( 2 );
 		let sizeColor;
 
@@ -135,8 +135,12 @@ const HMMediaWeightSidebar = () => {
 						</span>
 					</strong>
 				</p>
-				<p>{ __( 'Images total', 'hm-media-weight' ) }: { ( imagesSize / MB_IN_B ).toFixed( 2 ) }mb</p>
-				<p>{ __( 'Videos total', 'hm-media-weight' ) }: { ( videosSize / MB_IN_B ).toFixed( 2 ) }mb</p>
+				{ imageCount !== 0 && (
+					<p>{ __( 'Images total', 'hm-media-weight' ) }: { ( imagesSize / MB_IN_B ).toFixed( 2 ) }mb</p>
+				) }
+				{ videoCount !== 0 && (
+					<p>{ __( 'Videos total', 'hm-media-weight' ) }: { ( videosSize / MB_IN_B ).toFixed( 2 ) }mb</p>
+				) }
 				{ warningMsg }
 			</>
 		);
@@ -196,7 +200,9 @@ const HMMediaWeightSidebar = () => {
 					<p>Videos: { videoCount }</p>
 
 					<DisplayTotal
+						imageCount={ imageCount }
 						imagesSize={ imagesSize }
+						videoCount={ videoCount }
 						videosSize={ videosSize }
 					/>
 				</PanelBody>

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import { PanelRow, PanelBody, Button, FlexItem, Flex } from '@wordpress/componen
 import { registerPlugin, unregisterPlugin } from '@wordpress/plugins';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
+import { store as editPostStore } from '@wordpress/edit-post';
 import { useEntityRecords } from '@wordpress/core-data';
 import { Icon, caution } from '@wordpress/icons';
 
@@ -86,6 +87,7 @@ const HMMediaWeightSidebar = () => {
 		videoCount
 	} = useMediaBlocks();
 	const { selectBlock } = useDispatch( blockEditorStore );
+	const { openGeneralSidebar } = useDispatch( editPostStore );
 	let imagesSize = 0;
 	let videosSize = 0;
 
@@ -152,7 +154,10 @@ const HMMediaWeightSidebar = () => {
 		const blockButton = attachment.id !== featuredImageId ? (
 			<Button
 				className="components-button is-compact is-secondary"
-				onClick={ () => selectBlock( associatedBlockClientId ) }
+				onClick={ () => {
+					selectBlock( associatedBlockClientId );
+					openGeneralSidebar( 'edit-post/block' );
+				} }
 			>
 				{ __( 'Select associated block', 'hm-media-weight' ) }
 			</Button> ) : '';


### PR DESCRIPTION
Some servers (Altis Tachyon, I'm lookin' at you) do not return the 'content-length' header, so we have to have a fallback way of getting image size.

Also declares support for WebP, to ensure that we get browser-accurate sizing.