### PR TITLE
Measure Media Weight with Performance API

### DIFF
--- a/inc/assets.php
+++ b/inc/assets.php
@@ -53,13 +53,14 @@ function register_block_plugin_editor_scripts() {
 			 *
 			 * @param float $threshold Maximum number of megabytes of media permitted per post.
 			 */
-			'mediaThreshold' => apply_filters( 'hm_media_weight_threshold', 2.50 ),
+			'mediaThreshold'    => apply_filters( 'hm_media_weight_threshold', 2.50 ),
 			/**
 			 * Filter the expected image size slug for a desktop featured image.
 			 *
 			 * @param string $size_slug String name of image size used for desktop featured image.
 			 */
 			'featuredImageSize' => apply_filters( 'hm_media_weight_featured_image_size_slug', 'large' ),
+			'previewPostLink'   => get_preview_post_link(),
 		]
 	);
 }

--- a/inc/assets.php
+++ b/inc/assets.php
@@ -53,14 +53,13 @@ function register_block_plugin_editor_scripts() {
 			 *
 			 * @param float $threshold Maximum number of megabytes of media permitted per post.
 			 */
-			'mediaThreshold'    => apply_filters( 'hm_media_weight_threshold', 2.50 ),
+			'mediaThreshold' => apply_filters( 'hm_media_weight_threshold', 2.50 ),
 			/**
 			 * Filter the expected image size slug for a desktop featured image.
 			 *
 			 * @param string $size_slug String name of image size used for desktop featured image.
 			 */
 			'featuredImageSize' => apply_filters( 'hm_media_weight_featured_image_size_slug', 'large' ),
-			'previewPostLink'   => get_preview_post_link(),
 		]
 	);
 }

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -16,6 +16,7 @@ function bootstrap() : void {
 	add_action( 'add_attachment', __NAMESPACE__ . '\\schedule_file_size_check' );
 	add_action( ATTACHMENT_SIZE_CRON_ID, __NAMESPACE__ . '\\store_intermediate_file_sizes' );
 	add_action( 'rest_prepare_attachment', __NAMESPACE__ . '\\lookup_file_sizes_as_needed_during_rest_response', 10, 3 );
+	add_action( 'wp_head', __NAMESPACE__ . '\\get_performance_entries' );
 }
 
 /**
@@ -163,4 +164,26 @@ function lookup_file_sizes_as_needed_during_rest_response( $response, $post, $re
 	}
 
 	return $response;
+}
+
+/**
+ * Prints script to the head tag for passing PerformanceEntry
+ * objects to the postMessage method when adding an iframe.
+ *
+ * @return void
+ */
+function get_performance_entries() {
+	// Bail if mediaWeight URL param is not set.
+	if ( ! isset( $_GET['mediaWeight'] ) ) {
+		return;
+	}
+
+	?>
+	<script>
+		const entries = window.performance.getEntriesByType( 'resource' );
+		window.addEventListener( 'load', () => {
+			window.parent.postMessage( JSON.stringify( entries ) );
+		} );
+	</script>
+	<?php
 }

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -16,7 +16,7 @@ function bootstrap() : void {
 	add_action( 'add_attachment', __NAMESPACE__ . '\\schedule_file_size_check' );
 	add_action( ATTACHMENT_SIZE_CRON_ID, __NAMESPACE__ . '\\store_intermediate_file_sizes' );
 	add_action( 'rest_prepare_attachment', __NAMESPACE__ . '\\lookup_file_sizes_as_needed_during_rest_response', 10, 3 );
-	add_action( 'wp_head', __NAMESPACE__ . '\\get_performance_entries' );
+	add_action( 'wp_head', __NAMESPACE__ . '\\output_performance_entries' );
 }
 
 /**
@@ -172,7 +172,7 @@ function lookup_file_sizes_as_needed_during_rest_response( $response, $post, $re
  *
  * @return void
  */
-function get_performance_entries() {
+function output_performance_entries() {
 	// Bail if mediaWeight URL param is not set.
 	if ( ! isset( $_GET['mediaWeight'] ) ) {
 		return;

--- a/src/index.js
+++ b/src/index.js
@@ -232,6 +232,7 @@ const HMMediaWeightSidebar = () => {
 	useEffect( () => {
 		window.addEventListener( 'message', ( event ) => {
 			const receivedEntries = event.data;
+			// eslint-disable-next-line no-console
 			console.log( receivedEntries );
 		} );
 	}, [ iframeURL ] );

--- a/src/index.js
+++ b/src/index.js
@@ -9,10 +9,11 @@ import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as editPostStore } from '@wordpress/edit-post';
 import { useEntityRecords } from '@wordpress/core-data';
 import { Icon, caution } from '@wordpress/icons';
+import { addQueryArgs } from '@wordpress/url';
 
 import { ReactComponent as ScalesIcon } from './assets/scale-icon.svg';
 
-const { mediaThreshold, featuredImageSize, previewPostLink } = window.mediaWeightData;
+const { mediaThreshold, featuredImageSize } = window.mediaWeightData;
 
 const PLUGIN_NAME = 'hm-media-weight';
 const SIDEBAR_NAME = PLUGIN_NAME;
@@ -196,9 +197,12 @@ const HMMediaWeightSidebar = () => {
 	} );
 
 	const insertIframe = ( url, width = '1600px', height = '800px' ) => {
-		const iframeExists = document.getElementById( 'post-preview-iframe' );
+		const iframeWindow = document.getElementById( 'post-preview-iframe' );
 
-		if ( ! iframeExists ) {
+		if ( iframeWindow ) {
+			// Reload the iframe to recalculate performance entries.
+			iframeWindow.contentWindow.location.reload();
+		} else {
 			const iframe = document.createElement( 'iframe' );
 			iframe.src = url;
 			iframe.width = width;
@@ -209,33 +213,21 @@ const HMMediaWeightSidebar = () => {
 		}
 	}
 
-	const addQueryString = ( url, params ) => {
-		const urlObject = new URL( url );
-		const searchParams = new URLSearchParams( urlObject.search );
-
-		for ( const key in params ) {
-			if ( params.hasOwnProperty( key ) ) {
-				searchParams.set( key, params[key] );
-			}
-		}
-
-		urlObject.search = searchParams.toString();
-
-		return urlObject.toString();
-	}
-
-	const newParams = {
-		mediaWeight: '1'
-	};
-	const iframeURL = addQueryString( previewPostLink, newParams );
+	const previewPostLink = useSelect( ( select ) => select( 'core/editor' ).getEditedPostPreviewLink() );
+	const iframeURL = addQueryArgs( previewPostLink, { mediaWeight: '1' } );
 
 	useEffect( () => {
-		window.addEventListener( 'message', ( event ) => {
+		const listener = window.addEventListener( 'message', ( event ) => {
 			const receivedEntries = event.data;
 			// eslint-disable-next-line no-console
 			console.log( receivedEntries );
+			// You can call a useState callback here to get the data into the component.
 		} );
-	}, [ iframeURL ] );
+
+		return () => {
+			window.removeEventListener( listener );
+		};
+	}, [] );
 
 	return (
 		<PluginSidebar className={ SIDEBAR_NAME } title={ __( 'Media Weight', 'hm-media-weight' ) }>

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import { PluginSidebar } from '@wordpress/editor';
 import { PanelRow, PanelBody, Button, FlexItem, Flex } from '@wordpress/components';
 import { registerPlugin, unregisterPlugin } from '@wordpress/plugins';
 import { useDispatch, useSelect } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as editPostStore } from '@wordpress/edit-post';
 import { useEntityRecords } from '@wordpress/core-data';
@@ -11,7 +12,7 @@ import { Icon, caution } from '@wordpress/icons';
 
 import { ReactComponent as ScalesIcon } from './assets/scale-icon.svg';
 
-const { mediaThreshold, featuredImageSize } = window.mediaWeightData;
+const { mediaThreshold, featuredImageSize, previewPostLink } = window.mediaWeightData;
 
 const PLUGIN_NAME = 'hm-media-weight';
 const SIDEBAR_NAME = PLUGIN_NAME;
@@ -194,8 +195,60 @@ const HMMediaWeightSidebar = () => {
 		};
 	} );
 
+	const insertIframe = ( url, width = '1600px', height = '800px' ) => {
+		const iframeExists = document.getElementById( 'post-preview-iframe' );
+
+		if ( ! iframeExists ) {
+			const iframe = document.createElement( 'iframe' );
+			iframe.src = url;
+			iframe.width = width;
+			iframe.height = height;
+			iframe.id = 'post-preview-iframe';
+			iframe.style.display = 'none';
+			document.body.appendChild( iframe );
+		}
+	}
+
+	const addQueryString = ( url, params ) => {
+		const urlObject = new URL( url );
+		const searchParams = new URLSearchParams( urlObject.search );
+
+		for ( const key in params ) {
+			if ( params.hasOwnProperty( key ) ) {
+				searchParams.set( key, params[key] );
+			}
+		}
+
+		urlObject.search = searchParams.toString();
+
+		return urlObject.toString();
+	}
+
+	const newParams = {
+		mediaWeight: '1'
+	};
+	const iframeURL = addQueryString( previewPostLink, newParams );
+
+	useEffect( () => {
+		window.addEventListener( 'message', ( event ) => {
+			const receivedEntries = event.data;
+			console.log( receivedEntries );
+		} );
+	}, [ iframeURL ] );
+
 	return (
 		<PluginSidebar className={ SIDEBAR_NAME } title={ __( 'Media Weight', 'hm-media-weight' ) }>
+			<PanelBody>
+				<Button
+					className="components-button is-compact is-secondary"
+					onClick={ () => {
+						insertIframe( iframeURL );
+					} }
+				>
+					{ __( 'Get Performance API Entries', 'hm-media-weight' ) }
+				</Button>
+			</PanelBody>
+
 			<PanelBody
 				initialOpen={ true }
 				title={ __( 'Total Media Items', 'hm-media-weight' ) }

--- a/src/index.js
+++ b/src/index.js
@@ -217,17 +217,46 @@ const HMMediaWeightSidebar = () => {
 	const iframeURL = addQueryArgs( previewPostLink, { mediaWeight: '1' } );
 
 	useEffect( () => {
-		const listener = window.addEventListener( 'message', ( event ) => {
-			const receivedEntries = event.data;
+		const listener = ( event ) => {
+			let receivedEntries = event.data;
+			let mediaEntries = {};
+
+			receivedEntries = JSON.parse( receivedEntries );
+
+			// Select only images and videos.
+			const filteredEntries = receivedEntries.filter( ( entry ) => {
+				return entry.initiatorType === 'img' || entry.initiatorType === 'video';
+			} );
+
+			filteredEntries.forEach( ( entry, index ) => {
+				let mediaID;
+
+				for ( const attachment of attachments ) {
+					if ( ! entry.name.includes( attachment.generated_slug ) ) {
+						continue;
+					}
+
+					mediaID = attachment.id;
+				};
+
+				mediaEntries[index] = {
+					mediaID: mediaID ? mediaID : null,
+					mediaSize: entry.encodedBodySize,
+					mediaType: entry.initiatorType,
+					mediaURL: entry.name,
+				};
+			} );
+
 			// eslint-disable-next-line no-console
-			console.log( receivedEntries );
-			// You can call a useState callback here to get the data into the component.
-		} );
+			console.log( mediaEntries );
+		}
+
+		window.addEventListener( 'message', listener );
 
 		return () => {
-			window.removeEventListener( listener );
+			window.removeEventListener( 'message', listener );
 		};
-	}, [] );
+	}, [ attachments ] );
 
 	return (
 		<PluginSidebar className={ SIDEBAR_NAME } title={ __( 'Media Weight', 'hm-media-weight' ) }>

--- a/src/index.js
+++ b/src/index.js
@@ -219,7 +219,7 @@ const HMMediaWeightSidebar = () => {
 	useEffect( () => {
 		const listener = ( event ) => {
 			let receivedEntries = event.data;
-			let mediaEntries = {};
+			const mediaEntries = {};
 
 			receivedEntries = JSON.parse( receivedEntries );
 


### PR DESCRIPTION
This change builds off of PR #11 and introduces a way to pull asset data from the front-end using the browser's Performance API within a post preview URL iframe.

This allows for the media sizes to reflect what is being served in the front-end and can be used to calculate media weight at different screen sizes.

The draft PR is a WIP and a proof-of-concept based on @roborourke's initial research and pseudo code.