### PR TITLE
Media weight rework using performance api 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ node_modules/
 
 # Built files
 build/
+
+# vendor files
+vendor/

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
 	"type": "wordpress-plugin",
 	"homepage": "https://humanmade.com",
 	"license": "GPL-2.0+",
-	"version": "0.1.0",
+	"version": "0.2.0",
 	"require": {
 		"php": ">=8.1"
 	}

--- a/inc/assets.php
+++ b/inc/assets.php
@@ -53,13 +53,14 @@ function register_block_plugin_editor_scripts() {
 			 *
 			 * @param float $threshold Maximum number of megabytes of media permitted per post.
 			 */
-			'mediaThreshold' => apply_filters( 'hm_media_weight_threshold', 2.50 ),
+			'mediaThreshold'    => apply_filters( 'hm_media_weight_threshold', 2.50 ),
 			/**
 			 * Filter the expected image size slug for a desktop featured image.
 			 *
 			 * @param string $size_slug String name of image size used for desktop featured image.
 			 */
 			'featuredImageSize' => apply_filters( 'hm_media_weight_featured_image_size_slug', 'large' ),
+			'previewPostLink'   => get_preview_post_link(),
 		]
 	);
 }

--- a/inc/assets.php
+++ b/inc/assets.php
@@ -53,14 +53,13 @@ function register_block_plugin_editor_scripts() {
 			 *
 			 * @param float $threshold Maximum number of megabytes of media permitted per post.
 			 */
-			'mediaThreshold'    => apply_filters( 'hm_media_weight_threshold', 2.50 ),
+			'mediaThreshold' => apply_filters( 'hm_media_weight_threshold', 2.50 ),
 			/**
 			 * Filter the expected image size slug for a desktop featured image.
 			 *
 			 * @param string $size_slug String name of image size used for desktop featured image.
 			 */
 			'featuredImageSize' => apply_filters( 'hm_media_weight_featured_image_size_slug', 'large' ),
-			'previewPostLink'   => get_preview_post_link(),
 		]
 	);
 }

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -16,6 +16,7 @@ function bootstrap() : void {
 	add_action( 'add_attachment', __NAMESPACE__ . '\\schedule_file_size_check' );
 	add_action( ATTACHMENT_SIZE_CRON_ID, __NAMESPACE__ . '\\store_intermediate_file_sizes' );
 	add_action( 'rest_prepare_attachment', __NAMESPACE__ . '\\lookup_file_sizes_as_needed_during_rest_response', 10, 3 );
+	add_action( 'wp_head', __NAMESPACE__ . '\\get_performance_entries' );
 }
 
 /**
@@ -163,4 +164,26 @@ function lookup_file_sizes_as_needed_during_rest_response( $response, $post, $re
 	}
 
 	return $response;
+}
+
+/**
+ * Prints script to the head tag for passing PerformanceEntry
+ * objects to the postMessage method when adding an iframe.
+ *
+ * @return void
+ */
+function get_performance_entries() {
+	// Bail if mediaWeight URL param is not set.
+	if ( ! isset( $_GET['mediaWeight'] ) ) {
+		return;
+	}
+
+	?>
+	<script>
+		const entries = window.performance.getEntriesByType( 'resource' );
+		window.addEventListener( 'load', () => {
+			window.parent.postMessage( JSON.stringify( entries ) );
+		} );
+	</script>
+	<?php
 }

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -5,165 +5,24 @@
 
 namespace HM_Media_Weight;
 
-const ATTACHMENT_SIZE_CRON_ID = 'hm-media-weight-attachment-check';
-const ATTACHMENT_SIZE_META_KEY = 'intermediate_image_filesizes';
-
 /**
  * Connect namespace functions to actions and hooks.
  */
 function bootstrap() : void {
-	add_action( 'init', __NAMESPACE__ . '\register_attachment_meta' );
-	add_action( 'add_attachment', __NAMESPACE__ . '\\schedule_file_size_check' );
-	add_action( ATTACHMENT_SIZE_CRON_ID, __NAMESPACE__ . '\\store_intermediate_file_sizes' );
-	add_action( 'rest_prepare_attachment', __NAMESPACE__ . '\\lookup_file_sizes_as_needed_during_rest_response', 10, 3 );
-	add_action( 'wp_head', __NAMESPACE__ . '\\output_performance_entries' );
-}
+	// Track resource sizes in the iframed preview, reporting results to the editor window.
+	add_action( 'wp_head', __NAMESPACE__ . '\\output_resource_tracking_on_preview' );
 
-/**
- * Registers the _image_file_sizes meta field for the attachment post type.
- */
-function register_attachment_meta() {
-	register_post_meta( 'attachment', ATTACHMENT_SIZE_META_KEY, [
-		'type'         => 'object',
-		'description'  => 'File sizes for all intermediate image sizes of an attachment.',
-		'single'       => true,
-		'show_in_rest' => [
-			'schema' => [
-				'type' => 'object',
-				'additionalProperties' => [
-					'type' => 'integer',
-				],
-			],
-		],
-		'auth_callback' => function() {
-			return current_user_can( 'edit_posts' );
-		},
-	] );
-}
+	// Disable analytics script injection to avoid skewing media weight measurements. Run before Altis Analytics hooks in.
+	add_action( 'plugins_loaded', __NAMESPACE__ . '\disable_analytics_script_injection', 11 );
 
-/**
- * Schedules a cron job to check file sizes for the uploaded attachment.
- *
- * @param int $attachment_id The ID of the uploaded attachment.
- */
-function schedule_file_size_check( $attachment_id ) {
-	if ( ! in_array( get_post_mime_type( $attachment_id ), [ 'image/jpeg', 'image/png', 'image/gif' ], true ) ) {
-		return;
-	}
+	// Disable lazy loading for iframes in media weight preview.
+	add_filter( 'wp_lazy_loading_enabled', __NAMESPACE__ . '\disable_lazy_loading_for_iframes_in_preview', PHP_INT_MAX );
 
-	if ( ! wp_next_scheduled( ATTACHMENT_SIZE_CRON_ID, [ $attachment_id ] ) ) {
-		// Ensure the cron job is scheduled for later as fallback.
-		wp_schedule_single_event( time(), ATTACHMENT_SIZE_CRON_ID, [ $attachment_id ] );
-	}
-}
+	// Output some shimmer styles for the media weight loading state to wp-admin footer.
+	add_action( 'admin_footer', __NAMESPACE__ . '\\output_shimmer_styles' );
 
-/**
- * Logs the file sizes for each image size of the uploaded attachment.
- *
- * Image weights are retrieved via remote request against the image's URI.
- *
- * @param int $attachment_id The ID of the uploaded attachment.
- */
-function store_intermediate_file_sizes( $attachment_id ) {
-	/**
-	 * Filter which size slugs we retrieve image size information for.
-	 *
-	 * Enables a site from skipping computation (remote request) for any size
-	 * slugs that are explicitly not expected/allowed to be used in posts.
-	 *
-	 * @param string[] $calculated_image_sizes Maximum number of megabytes of media permitted per post.
-	 */
-	$image_sizes = apply_filters( 'hm_media_weight_calculated_sizes', get_intermediate_image_sizes() );
-	$file_sizes  = [];
-
-	foreach ( $image_sizes as $size ) {
-		$image_url = wp_get_attachment_image_url( $attachment_id, $size );
-
-		if ( ! $image_url ) {
-			continue;
-		}
-
-		// Pass an Accept header to ensure we'll get webp sizing results if that
-		// format is supported by the server.
-		$args = [
-			'headers' => [ 'Accept' => 'image/webp' ],
-		];
-		$response = wp_remote_head( $image_url, $args );
-
-		if ( is_wp_error( $response ) ) {
-			continue;
-		}
-
-		$headers = wp_remote_retrieve_headers( $response );
-		if ( ! empty( $headers['content-length'] ) ) {
-			$file_sizes[ $size ] = (int) $headers['content-length'];
-			continue;
-		}
-
-		// If head request didn't work, server may not expose response content-length.
-		// Instead, try a get and read the response string's length. This is obviously
-		// less efficient, but measures accurately.
-		$response = wp_remote_get( $image_url, $args );
-
-		if ( is_wp_error( $response ) ) {
-			continue;
-		}
-
-		if ( ( $response['response']['code'] ?? null ) === 200 && ! empty( $response['body'] ) ) {
-			$file_sizes[ $size ] = (int) strlen( $response['body'] );
-		}
-	}
-
-	// Save the file sizes to the attachment meta.
-	update_post_meta( $attachment_id, ATTACHMENT_SIZE_META_KEY, $file_sizes );
-}
-
-/**
- * Retrieves the file sizes for an attachment.
- *
- * @param int $attachment_id The ID of the attachment.
- * @return array|null The array of file sizes keyed by URL, or null if not available.
- */
-function get_file_sizes( $attachment_id ) {
-	return get_post_meta( $attachment_id, ATTACHMENT_SIZE_META_KEY, true ) ?: [];
-}
-
-/**
- * Conditionally request and fill in missing file size meta before fulfilling
- * an edit-context REST request for an image.
- *
- * @param WP_REST_Response $response The response object.
- * @param WP_Post          $post     The original attachment post.
- * @param WP_REST_Request  $request  Request used to generate the response.
- * @return WP_REST_Response The filtered response.
- */
-function lookup_file_sizes_as_needed_during_rest_response( $response, $post, $request ) {
-	if ( $request->get_param( 'context' ) !== 'edit' ) {
-		return $response;
-	}
-
-	if ( ! empty( $response->data['meta'][ ATTACHMENT_SIZE_META_KEY ] ?? null ) ) {
-		return $response;
-	}
-
-	$meta_field_included = rest_is_field_included(
-		'meta.' . ATTACHMENT_SIZE_META_KEY,
-		get_post_type_object( 'attachment' )->get_rest_controller()->get_fields_for_response( $request ) ?? []
-	);
-	if ( ! $meta_field_included ) {
-		return $response;
-	}
-
-	// Update post meta and then append the stored values to the response.
-	store_intermediate_file_sizes( $post->ID );
-	$response->data['meta'][ ATTACHMENT_SIZE_META_KEY ] = get_file_sizes( $post->ID );
-
-	// Ensure we consistently return object-shaped JSON, not `[]` for empty.
-	if ( empty( $response->data['meta'][ ATTACHMENT_SIZE_META_KEY ] ) && isset( $response->data['meta'][ ATTACHMENT_SIZE_META_KEY ] ) ) {
-		$response->data['meta'][ ATTACHMENT_SIZE_META_KEY ] = (object) [];
-	}
-
-	return $response;
+	// Remove autoplay from video blocks in the media weight preview - use the render_block filter.
+	add_filter( 'render_block', __NAMESPACE__ . '\\remove_video_autoplay_in_preview', 10, 2 );
 }
 
 /**
@@ -172,18 +31,136 @@ function lookup_file_sizes_as_needed_during_rest_response( $response, $post, $re
  *
  * @return void
  */
-function output_performance_entries() {
+function output_resource_tracking_on_preview() {
 	// Bail if mediaWeight URL param is not set.
 	if ( ! isset( $_GET['mediaWeight'] ) ) {
 		return;
 	}
 
+?>
+<script>
+	// Collect all resource information once the page is fully loaded.
+	// Ensure lazy loaded elements like videos are also loaded.
+	window.addEventListener( 'load', () => {
+		// Start at top, then scroll to bottom
+		setTimeout( () => {
+			window.scrollTo({
+				top: 0,
+				behavior: 'smooth'
+			});
+			setTimeout( () => {
+				window.scrollTo({
+					top: document.body.scrollHeight,
+					behavior: 'smooth'
+				});
+				setTimeout(() => {
+					const entries = window.performance.getEntriesByType( 'resource' );
+					window.parent.postMessage( JSON.stringify( filterEntriesToContent( entries ) ) );
+				}, 2000 );
+			}, 500);
+		}, 100 );
+	} );
+
+	/**
+	 * For the purposes of limiting to content the author controls, limit to media
+	 * contained in the class="article-main-section" div, excluding byline avatar images
+	 * from the "post-single__bylines" div.
+	 *
+	 * @param {PerformanceEntry[]} entries Array of performance entries.
+	 * @return {PerformanceEntry[]} Filtered array of performance entries.
+	 */
+	function filterEntriesToContent( entries ) {
+		const articleMainSection = document.querySelector( '.article-main-section' );
+		const avatarBylines = document.querySelector( '.post-single__bylines' );
+		if ( articleMainSection ) {
+			entries = entries.filter( ( entry ) => {
+				// Look for an image with the srcset containing the entity name.
+				const element = document.querySelector( `img[srcset*="${ entry.name }"]` );
+				const hasImage = articleMainSection.contains( element ) && ( ! avatarBylines || ! avatarBylines.contains( element ) );
+
+				// Look for videos with the src containing the entity name.
+				const videoElement = document.querySelector( `video[src*="${ entry.name }"]` );
+				const hasVideo = articleMainSection.contains( videoElement );
+
+				return hasImage || hasVideo;
+			} );
+		}
+		return entries;
+	}
+</script>
+<?php
+}
+
+/**
+ * Disable analytics script injection in the iframe preview to avoid a
+ * conflict with media weight measurements.
+ */
+function disable_analytics_script_injection() {
+	if ( ! isset( $_GET['mediaWeight'] ) ) {
+		return;
+	}
+
+	remove_action( 'wp_head', 'Altis\Analytics\\enqueue_scripts', 0 );
+}
+
+/**
+ * Disable lazy loading for iframes in media weight preview.
+ *
+ * @param bool $lazy Whether lazy loading is enabled.
+ * @return bool Modified lazy loading setting.
+ */
+function disable_lazy_loading_for_iframes_in_preview( $lazy ) {
+	if ( isset( $_GET['mediaWeight'] ) ) {
+		return false;
+	}
+	return $lazy;
+}
+
+/**
+ * Add a shimmer style for media weight loading states to wp-admin footer.
+ */
+function output_shimmer_styles() : void {
 	?>
-	<script>
-		const entries = window.performance.getEntriesByType( 'resource' );
-		window.addEventListener( 'load', () => {
-			window.parent.postMessage( JSON.stringify( entries ) );
-		} );
-	</script>
+
+	<style>
+		/* Shimmer effect for loading */
+		@keyframes shimmer {
+			0% {
+				background-position: -200px 0;
+			}
+			100% {
+				background-position: 200px 0;
+			}
+		}
+		.media-weight-placeholder {
+			animation-duration: 1.5s;
+			animation-fill-mode: forwards;
+			animation-iteration-count: infinite;
+			animation-name: shimmer;
+			animation-timing-function: linear;
+			background: #f6f7f8;
+			background: linear-gradient(to right, #eeeeee 8%, #dddddd 18%, #eeeeee 33%);
+			background-size: 800px 104px;
+			position: relative;
+		}
+	</style>
 	<?php
+}
+
+/**
+ * Remove autoplay from videos in the media weight preview.
+ *
+ * Filters the html of the core video block to remove the autoplay attribute.
+ */
+function remove_video_autoplay_in_preview( $block_content, $block ) {
+	if ( ! isset( $_GET['mediaWeight'] ) ) {
+		return $block_content;
+	}
+
+	if ( 'core/video' === $block['blockName'] ) {
+		$block_content = str_replace( ' autoplay="autoplay"', '', $block_content );
+		$block_content = str_replace( ' autoplay', '', $block_content );
+	}
+
+	return $block_content;
 }

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -16,7 +16,7 @@ function bootstrap() : void {
 	add_action( 'add_attachment', __NAMESPACE__ . '\\schedule_file_size_check' );
 	add_action( ATTACHMENT_SIZE_CRON_ID, __NAMESPACE__ . '\\store_intermediate_file_sizes' );
 	add_action( 'rest_prepare_attachment', __NAMESPACE__ . '\\lookup_file_sizes_as_needed_during_rest_response', 10, 3 );
-	add_action( 'wp_head', __NAMESPACE__ . '\\get_performance_entries' );
+	add_action( 'wp_head', __NAMESPACE__ . '\\output_performance_entries' );
 }
 
 /**
@@ -172,7 +172,7 @@ function lookup_file_sizes_as_needed_during_rest_response( $response, $post, $re
  *
  * @return void
  */
-function get_performance_entries() {
+function output_performance_entries() {
 	// Bail if mediaWeight URL param is not set.
 	if ( ! isset( $_GET['mediaWeight'] ) ) {
 		return;

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -71,15 +71,14 @@ function output_resource_tracking_on_preview() {
 	function filterEntriesToContent( entries ) {
 		const articleMainSection = document.querySelector( '.article-main-section' );
 		const avatarBylines      = document.querySelector( '.post-single__bylines' );
-
 		if ( articleMainSection ) {
 			entries = entries.filter( ( entry ) => {
 				// Look for an image with the srcset containing the entity name.
-				const element  = document.querySelector( `img[srcset*="${ esc_attr( entry.name ) }"]` );
+				const element  = document.querySelector( `img[srcset*="${ entry.name }"]` );
 				const hasImage = articleMainSection.contains( element ) && ( ! avatarBylines || ! avatarBylines.contains( element ) );
 
 				// Look for videos with the src containing the entity name.
-				const videoElement = document.querySelector( `video[src*="${ esc_attr( entry.name ) }"]` );
+				const videoElement = document.querySelector( `video[src*="${ entry.name }"]` );
 				const hasVideo     = articleMainSection.contains( videoElement );
 
 				return hasImage || hasVideo;

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -36,7 +36,6 @@ function output_resource_tracking_on_preview() {
 	if ( ! isset( $_GET['mediaWeight'] ) ) {
 		return;
 	}
-
 ?>
 <script>
 	// Collect all resource information once the page is fully loaded.
@@ -121,7 +120,6 @@ function disable_lazy_loading_for_iframes_in_preview( $lazy ) {
  */
 function output_shimmer_styles() : void {
 	?>
-
 	<style>
 		/* Shimmer effect for loading */
 		@keyframes shimmer {

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -53,9 +53,9 @@ function output_resource_tracking_on_preview() {
 					behavior: 'smooth'
 				});
 				setTimeout(() => {
-					const entries = window.performance.getEntriesByType( 'resource' );
-					window.parent.postMessage( JSON.stringify( filterEntriesToContent( entries ) ) );
-				}, 2000 );
+				const entries = window.performance.getEntriesByType( 'resource' );
+				window.parent.postMessage( JSON.stringify( filterEntriesToContent( entries ) ), window.location.origin );
+			}, 2000 );
 			}, 500);
 		}, 100 );
 	} );
@@ -70,16 +70,17 @@ function output_resource_tracking_on_preview() {
 	 */
 	function filterEntriesToContent( entries ) {
 		const articleMainSection = document.querySelector( '.article-main-section' );
-		const avatarBylines = document.querySelector( '.post-single__bylines' );
+		const avatarBylines      = document.querySelector( '.post-single__bylines' );
+
 		if ( articleMainSection ) {
 			entries = entries.filter( ( entry ) => {
 				// Look for an image with the srcset containing the entity name.
-				const element = document.querySelector( `img[srcset*="${ entry.name }"]` );
+				const element  = document.querySelector( `img[srcset*="${ esc_attr( entry.name ) }"]` );
 				const hasImage = articleMainSection.contains( element ) && ( ! avatarBylines || ! avatarBylines.contains( element ) );
 
 				// Look for videos with the src containing the entity name.
-				const videoElement = document.querySelector( `video[src*="${ entry.name }"]` );
-				const hasVideo = articleMainSection.contains( videoElement );
+				const videoElement = document.querySelector( `video[src*="${ esc_attr( entry.name ) }"]` );
+				const hasVideo     = articleMainSection.contains( videoElement );
 
 				return hasImage || hasVideo;
 			} );

--- a/media-weight.php
+++ b/media-weight.php
@@ -3,7 +3,7 @@
  * Plugin Name:       HM Media Weight
  * Description:       Block Editor plugin to monitor approximate media bandwidth usage on a post.
  * Requires PHP:      8.1
- * Version:           0.1.0
+ * Version:           0.2.0
  * Author:            Human Made Ltd
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html

--- a/media-weight.php
+++ b/media-weight.php
@@ -21,3 +21,4 @@ require_once __DIR__ . '/inc/assets.php';
 
 bootstrap();
 Assets\bootstrap();
+

--- a/src/index.js
+++ b/src/index.js
@@ -151,7 +151,7 @@ const HMMediaWeightSidebar = () => {
 						animation: 'shimmer 1.5s infinite linear',
 					} }
 				>
-					<Flex gap={ 2 } align="center" justify="flex-start">
+					<Flex gap={ 2 } align="center" justify="center">
 						<SkeletonBox width="20px" height="20px" style={ { flexShrink: 0 } } />
 						<SkeletonBox width="65px" height="20px" style={ { flexShrink: 0 } } />
 						<SkeletonBox width="55px" height="18px" style={ { flexShrink: 0 } } />
@@ -161,11 +161,11 @@ const HMMediaWeightSidebar = () => {
 
 			{ /* Skeleton for media breakdown */ }
 			<Flex direction="column" gap={ 2 }>
-				<Flex gap={ 2 } align="center" justify="flex-start">
+				<Flex gap={ 2 } align="center" justify="center">
 					<SkeletonBox width="20px" height="20px" style={ { flexShrink: 0 } } />
 					<SkeletonBox width="150px" height="18px" style={ { flexShrink: 0 } } />
 				</Flex>
-				<Flex gap={ 2 } align="center" justify="flex-start">
+				<Flex gap={ 2 } align="center" justify="center">
 					<SkeletonBox width="20px" height="20px" style={ { flexShrink: 0 } } />
 					<SkeletonBox width="145px" height="18px" style={ { flexShrink: 0 } } />
 				</Flex>
@@ -436,7 +436,7 @@ const HMMediaWeightSidebar = () => {
 					{ /* Media Breakdown Section */ }
 					{ ! isFetchingPreview && previewEntries.length > 0 && (
 						<Flex direction="column" gap={ 2 }>
-							<Flex gap={ 2 } align="center" justify="flex-start">
+							<Flex gap={ 2 } align="center" justify="center">
 								<Icon icon={ image } size={ 18 } style={ { opacity: 0.7, flexShrink: 0 } } />
 								<span>
 									{ imagePreviewEntries.length
@@ -450,7 +450,7 @@ const HMMediaWeightSidebar = () => {
 									}
 								</span>
 							</Flex>
-							<Flex gap={ 2 } align="center" justify="flex-start">
+							<Flex gap={ 2 } align="center" justify="center">
 								<Icon icon={ video } size={ 18 } style={ { opacity: 0.7, flexShrink: 0 } } />
 								<span>
 									{ videoPreviewEntries.length
@@ -512,6 +512,7 @@ const HMMediaWeightSidebar = () => {
 					{ /* Refresh Button */ }
 					<Button
 						variant="secondary"
+						style={ { justifyContent: 'center' } }
 						onClick={ () => insertPreviewIframe( iframeURL, previewPlatform ) }
 						disabled={ isFetchingPreview }
 						aria-label={ __( 'Refresh preview data to recalculate media weight', 'hm-media-weight' ) }

--- a/src/index.js
+++ b/src/index.js
@@ -1,24 +1,61 @@
-import { useMemo } from 'react';
+import { useMemo, useState, useCallback } from 'react';
 import { __, sprintf } from '@wordpress/i18n';
 import { PluginSidebar } from '@wordpress/editor';
-import { PanelRow, PanelBody, Button, FlexItem, Flex } from '@wordpress/components';
+import {
+	PanelBody,
+	Button,
+	SelectControl,
+	Notice,
+	Flex,
+	Icon,
+} from '@wordpress/components';
 import { registerPlugin, unregisterPlugin } from '@wordpress/plugins';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 import { store as blockEditorStore } from '@wordpress/block-editor';
-import { store as editPostStore } from '@wordpress/edit-post';
 import { useEntityRecords } from '@wordpress/core-data';
-import { Icon, caution } from '@wordpress/icons';
+import { check, warning, closeSmall, image, video } from '@wordpress/icons';
 import { addQueryArgs } from '@wordpress/url';
 
 import { ReactComponent as ScalesIcon } from './assets/scale-icon.svg';
 
-const { mediaThreshold, featuredImageSize } = window.mediaWeightData;
+const { mediaThreshold } = window.mediaWeightData;
 
 const PLUGIN_NAME = 'hm-media-weight';
 const SIDEBAR_NAME = PLUGIN_NAME;
 const MB_IN_B = 1024 * 1024;
-const KB_IN_B = 1024;
+
+const previewPlatforms = {
+	mobile: {
+		label: __( 'Mobile', 'hm-media-weight' ),
+		width: '390px',
+		height: '844px',
+		slug: 'mobile',
+	},
+	desktop: {
+		label: __( 'Desktop', 'hm-media-weight' ),
+		width: '1920px',
+		height: '1080px',
+		slug: 'desktop',
+	},
+};
+
+// Skeleton loading placeholder component.
+const SkeletonBox = ( { width = '100%', height = '16px', style = {} } ) => (
+	<div
+		aria-hidden="true"
+		style={ {
+			width,
+			height,
+			backgroundColor: '#e0e0e0',
+			borderRadius: '4px',
+			background: 'linear-gradient(90deg, #e0e0e0 25%, #f0f0f0 50%, #e0e0e0 75%)',
+			backgroundSize: '200px 100%',
+			animation: 'shimmer 1.5s infinite linear',
+			...style,
+		} }
+	/>
+);
 
 const getMediaBlocks = ( blocks ) => blocks.reduce(
 	( mediaBlocks, block ) => {
@@ -38,15 +75,13 @@ const useMediaBlocks = () => {
 	const featuredImageId = useSelect( ( select ) => select( 'core/editor' ).getEditedPostAttribute( 'featured_media' ) );
 
 	/* eslint-disable no-shadow */
-	const { imageIds, videoIds, blocksByAttributeId } = useMemo( () => {
+	const { imageIds, videoIds } = useMemo( () => {
 		const imageIds = [];
 		const videoIds = [];
-		const blocksByAttributeId = {};
 		for ( const block of mediaBlocks ) {
 			if ( ! block.attributes?.id ) {
 				continue;
 			}
-			blocksByAttributeId[ block.attributes.id ] = block.clientId;
 			if ( block.name === 'core/image' ) {
 				imageIds.push( block.attributes.id );
 			} else if ( block.name === 'core/video' ) {
@@ -56,7 +91,7 @@ const useMediaBlocks = () => {
 		if ( featuredImageId !== 0 ) {
 			imageIds.push( featuredImageId );
 		}
-		return { imageIds, videoIds, blocksByAttributeId };
+		return { imageIds, videoIds };
 	}, [ mediaBlocks, featuredImageId ] );
 	/* eslint-enable no-shadow */
 
@@ -71,185 +106,215 @@ const useMediaBlocks = () => {
 
 	return {
 		attachments: imageRecords.concat( videoRecords ),
-		featuredImageId,
-		blocksByAttributeId,
-		mediaBlocks,
-		imageCount: imageIds.length,
-		videoCount: videoIds.length,
 	};
 };
 
 const HMMediaWeightSidebar = () => {
 	const {
 		attachments,
-		featuredImageId,
-		blocksByAttributeId,
-		mediaBlocks,
-		imageCount,
-		videoCount
 	} = useMediaBlocks();
-	const { selectBlock } = useDispatch( blockEditorStore );
-	const { openGeneralSidebar } = useDispatch( editPostStore );
-	let imagesSize = 0;
-	let videosSize = 0;
 
-	// eslint-disable-next-line no-shadow
-	const DisplayTotal = ( { imageCount, imagesSize, videoCount, videosSize } ) => {
-		const total = ( ( imagesSize + videosSize ) / MB_IN_B ).toFixed( 2 );
-		let sizeColor;
+	// Performance API (“preview”) entries state.
+	const [ previewEntries, setPreviewEntries ] = useState( [] );
 
-		if ( total >= 0 && total <= ( mediaThreshold / 2 ) ) {
-			sizeColor = '#1db231';
-		} else if ( total >= ( mediaThreshold / 2 ) && total <= mediaThreshold ) {
-			sizeColor = '#da6201';
-		} else {
-			sizeColor = '#cf2e2e';
-		}
+	// Track fetching of preview to show a spinner.
+	const [ isFetchingPreview, setIsFetchingPreview ] = useState( false );
 
-		const warningMsg = total >= mediaThreshold ? (
-			<p className="description" style={
-				{
-					backgroundColor: '#1db231',
-					borderRadius: '2px',
-					color: '#fff',
-					padding: '3px 6px'
-				}
-			}>
-				{ sprintf(
-					/* translators: %f: Maximum allowed size (in megabytes) for all media on page. */
-					__( 'Warning! The media in this page exceeds the recommended threshold of %fmb', 'hm-media-weight' ),
-					mediaThreshold
-				) }
-			</p>
-		) : null;
+	// Track the preview calculation mode: default to 'mobile', the other option is 'desktop'.
+	const [ previewPlatform, setPreviewPlatform ] = useState( 'mobile' );
 
-		return (
-			<>
-				<p>
-					<strong>
-						{ __( 'Total media size', 'hm-media-weight' ) }: { ' ' }
-						<span style={
-							{
-								backgroundColor: sizeColor,
-								borderRadius: '2px',
-								color: '#fff',
-								padding: '3px 6px'
-							}
-						}>
-							{ total }mb
-						</span>
-					</strong>
-				</p>
-				{ imageCount !== 0 && (
-					<p>{ __( 'Images total', 'hm-media-weight' ) }: { ( imagesSize / MB_IN_B ).toFixed( 2 ) }mb</p>
-				) }
-				{ videoCount !== 0 && (
-					<p>{ __( 'Videos total', 'hm-media-weight' ) }: { ( videosSize / MB_IN_B ).toFixed( 2 ) }mb</p>
-				) }
-				{ warningMsg }
-			</>
+	// Track the iframe URL in state.
+	const [ iframeURL, setIframeURL ] = useState( null );
+
+	const mediaWeightHeader = sprintf(
+			/* translators: %s: Preview mode (mobile or desktop). */
+			__( '%s media weight', 'hm-media-weight' ),
+			previewPlatforms[ previewPlatform ].label
 		);
-	}
 
-	const attachmentSizeDetails = attachments.map( ( attachment ) => {
-		const associatedBlockClientId = blocksByAttributeId[ attachment.id ];
-		const blockButton = attachment.id !== featuredImageId ? (
-			<Button
-				className="components-button is-compact is-secondary"
-				onClick={ () => {
-					selectBlock( associatedBlockClientId );
-					openGeneralSidebar( 'edit-post/block' );
-				} }
-			>
-				{ __( 'Select associated block', 'hm-media-weight' ) }
-			</Button> ) : '';
+	// Skeleton loader to mimic the loaded state layout.
+	const MediaWeightSkeleton = () => (
+		<Flex direction="column" gap={ 4 } aria-label={ __( 'Loading media weight data…', 'hm-media-weight' ) }>
+			<div>
+				<p style={ { fontWeight: 600, marginBottom: '8px' } }>
+					{ mediaWeightHeader }
+				</p>
+				{ /* Status badge with shimmer background */ }
+				<div
+					aria-hidden="true"
+					style={ {
+						borderRadius: '4px',
+						padding: '8px 10px',
+						border: '1px solid #e0e0e0',
+						background: 'linear-gradient(90deg, #f0f0f0 25%, #fafafa 50%, #f0f0f0 75%)',
+						backgroundSize: '200px 100%',
+						animation: 'shimmer 1.5s infinite linear',
+					} }
+				>
+					<Flex gap={ 2 } align="center" justify="flex-start">
+						<SkeletonBox width="20px" height="20px" style={ { flexShrink: 0 } } />
+						<SkeletonBox width="65px" height="20px" style={ { flexShrink: 0 } } />
+						<SkeletonBox width="55px" height="18px" style={ { flexShrink: 0 } } />
+					</Flex>
+				</div>
+			</div>
 
-		let type = attachment.media_type === 'image' ? __( 'Image', 'hm-media-weight' ) : __( 'Video', 'hm-media-weight' );
-		if ( attachment.id === featuredImageId ) {
-			type = __( 'Featured image', 'hm-media-weight' );
-		}
-		let mediaSize = attachment.media_details.filesize;
-
-		let requestedSize = '';
-		if ( attachment.media_type === 'image' ) {
-			requestedSize = attachment.id !== featuredImageId
-				? mediaBlocks.find( ( block ) => block.clientId === associatedBlockClientId )?.attributes?.sizeSlug
-				: ( featuredImageSize || 'full' );
-			// Swap in the actual measured size of the target image, if available.
-			mediaSize = attachment.meta?.intermediate_image_filesizes?.[ requestedSize ] || mediaSize;
-			imagesSize = imagesSize + mediaSize;
-		} else {
-			videosSize = videosSize + mediaSize;
-		}
-
-		const thumbnail = attachment.media_type === 'image'
-			? ( attachment?.media_details?.sizes?.thumbnail?.source_url || attachment.source_url )
-			: null;
-
-		return {
-			attachment,
-			thumbnail,
-			type,
-			mediaSize,
-			blockButton,
-			requestedSize,
-		};
-	} );
-
-	const insertIframe = ( url, width = '1600px', height = '800px' ) => {
-		const iframeWindow = document.getElementById( 'post-preview-iframe' );
-
-		if ( iframeWindow ) {
-			// Reload the iframe to recalculate performance entries.
-			iframeWindow.contentWindow.location.reload();
-		} else {
-			const iframe = document.createElement( 'iframe' );
-			iframe.src = url;
-			iframe.width = width;
-			iframe.height = height;
-			iframe.id = 'post-preview-iframe';
-			iframe.style.display = 'none';
-			document.body.appendChild( iframe );
-		}
-	}
+			{ /* Skeleton for media breakdown */ }
+			<Flex direction="column" gap={ 2 }>
+				<Flex gap={ 2 } align="center" justify="flex-start">
+					<SkeletonBox width="20px" height="20px" style={ { flexShrink: 0 } } />
+					<SkeletonBox width="150px" height="18px" style={ { flexShrink: 0 } } />
+				</Flex>
+				<Flex gap={ 2 } align="center" justify="flex-start">
+					<SkeletonBox width="20px" height="20px" style={ { flexShrink: 0 } } />
+					<SkeletonBox width="145px" height="18px" style={ { flexShrink: 0 } } />
+				</Flex>
+			</Flex>
+		</Flex>
+	);
 
 	const previewPostLink = useSelect( ( select ) => select( 'core/editor' ).getEditedPostPreviewLink() );
-	const iframeURL = addQueryArgs( previewPostLink, { mediaWeight: '1' } );
+	useEffect( () => {
+		setIframeURL(
+			previewPostLink ?
+			addQueryArgs( previewPostLink, { mediaWeight: '1', previewPlatform, d: Date.now() } ) :
+			null
+		);
+	}, [ previewPostLink, previewPlatform ] );
+
+	const removePreviewIframe = () => {
+		const iframeToRemove = document.getElementById( 'post-preview-iframe' );
+		if ( iframeToRemove ) {
+			iframeToRemove.remove();
+		}
+	};
+
+	const insertPreviewIframe = useCallback( ( url, platform = 'mobile' ) => {
+		const { width, height } = previewPlatforms[ platform ];
+		setIsFetchingPreview( true );
+
+		// Remove existing iframe to ensure a fresh sized load.
+		removePreviewIframe();
+
+		const iframe = document.createElement( 'iframe' );
+		iframe.id = 'post-preview-iframe';
+
+		// Parse numeric values from width/height (remove 'px' suffix).
+		const numericWidth = parseInt( width, 10 );
+		const numericHeight = parseInt( height, 10 );
+
+		// Position iframe off-screen but visible.
+		iframe.width            = numericWidth;
+		iframe.height           = numericHeight;
+		iframe.style.width      = width;
+		iframe.style.height     = height;
+		iframe.style.minWidth   = width;
+		iframe.style.minHeight  = height;
+		iframe.style.maxWidth   = 'none';
+		iframe.style.position   = 'fixed';
+		iframe.style.left       = '-9999px';
+		iframe.style.top        = '0';
+		iframe.style.border     = 'none';
+		iframe.style.visibility = 'visible';
+		iframe.src              = url;
+
+		document.body.appendChild( iframe );
+	}, [] );
+
+	useEffect( () => {
+		if ( ! iframeURL ) {
+			return;
+		}
+
+		// Only trigger once the plugin sidebar is actually in the DOM (i.e. opened).
+		const sidebarSelector = `.${ SIDEBAR_NAME }`;
+		let tries = 0;
+		const maxTries = 50; // ~5s at 100ms
+
+		const intervalId = window.setInterval( () => {
+			tries++;
+			const sidebarIsOpen = Boolean( document.querySelector( sidebarSelector ) );
+
+			if ( ! sidebarIsOpen ) {
+				if ( tries >= maxTries ) {
+					window.clearInterval( intervalId );
+				}
+				return;
+			}
+
+			window.clearInterval( intervalId );
+			setPreviewEntries( [] );
+			insertPreviewIframe( iframeURL, previewPlatform );
+		}, 100 );
+
+		return () => {
+			window.clearInterval( intervalId );
+		};
+	}, [ iframeURL, insertPreviewIframe, previewPlatform ] );
 
 	useEffect( () => {
 		const listener = ( event ) => {
 			let receivedEntries = event.data;
-			const mediaEntries = {};
 
-			receivedEntries = JSON.parse( receivedEntries );
+			try {
+				receivedEntries = JSON.parse( receivedEntries );
+			} catch ( e ) {
+				// Not our payload.
+				return;
+			}
 
 			// Select only images and videos.
 			const filteredEntries = receivedEntries.filter( ( entry ) => {
 				return entry.initiatorType === 'img' || entry.initiatorType === 'video';
 			} );
 
-			filteredEntries.forEach( ( entry, index ) => {
-				let mediaID;
+			const nextPreviewEntries = filteredEntries
+				.map( ( entry ) => {
+					const previewSize = entry.transferSize || entry.encodedBodySize || 0;
 
-				for ( const attachment of attachments ) {
-					if ( ! entry.name.includes( attachment.generated_slug ) ) {
-						continue;
+					return {
+						previewSize,
+						initiatorType: entry.initiatorType,
+						url: entry.name,
+					};
+				} )
+				.filter( Boolean );
+
+			// Filter entries with duplicate urls, keeping the largest previewSize.
+			const uniqueEntriesMap = new Map();
+			for ( const entry of nextPreviewEntries ) {
+				if ( uniqueEntriesMap.has( entry.url ) ) {
+					const existingEntry = uniqueEntriesMap.get( entry.url );
+					if ( entry.previewSize > existingEntry.previewSize ) {
+						uniqueEntriesMap.set( entry.url, entry );
 					}
+				} else {
+					uniqueEntriesMap.set( entry.url, entry );
+				}
+			}
+			const uniquePreviewEntries = Array.from( uniqueEntriesMap.values() );
 
-					mediaID = attachment.id;
-				};
-
-				mediaEntries[index] = {
-					mediaID: mediaID ? mediaID : null,
-					mediaSize: entry.encodedBodySize,
-					mediaType: entry.initiatorType,
-					mediaURL: entry.name,
-				};
+			/**
+			 * Filter out external resources, for example images inserted from other domains.
+			 *
+			 * For cross-origin resources like third-party images, performance.getEntriesByType('resource') will return
+			 * entries, but transferSize and encodedBodySize will be 0 unless the server includes the Timing-Allow-Origin header.
+			 * Regardless, we want to make sure they are excluded from our calculations because they aren't part
+			 * of the page weight.
+			 */
+			const localDomain = window.location.hostname;
+			const finalPreviewEntries = uniquePreviewEntries.filter( ( entry ) => {
+				try {
+					const entryURL = new URL( entry.url );
+					return entryURL.hostname === localDomain;
+				} catch ( e ) {
+					return false;
+				}
 			} );
 
-			// eslint-disable-next-line no-console
-			console.log( mediaEntries );
-		}
+			setPreviewEntries( finalPreviewEntries );
+			setIsFetchingPreview( false );
+		};
 
 		window.addEventListener( 'message', listener );
 
@@ -258,108 +323,202 @@ const HMMediaWeightSidebar = () => {
 		};
 	}, [ attachments ] );
 
+	let previewBytesTotal = previewEntries.reduce( ( total, entry ) => total + ( entry.previewSize || 0 ), 0 );
+
+	previewBytesTotal = ( previewBytesTotal / MB_IN_B ).toFixed( 2 );
+
+	// Determine status level for accessibility (not just color)
+	let sizeStatus;
+	if ( previewBytesTotal >= 0 && previewBytesTotal <= ( mediaThreshold / 2 ) ) {
+		sizeStatus = 'good';
+	} else if ( previewBytesTotal >= ( mediaThreshold / 2 ) && previewBytesTotal <= mediaThreshold ) {
+		sizeStatus = 'warning';
+	} else {
+		sizeStatus = 'error';
+	}
+
+	// Status configuration for colors, icons, and labels
+	const statusConfig = {
+		good: {
+			color: '#00a32a',
+			backgroundColor: '#edfaef',
+			icon: check,
+			label: __( 'Good', 'hm-media-weight' ),
+		},
+		warning: {
+			color: '#dba617',
+			backgroundColor: '#fcf9e8',
+			icon: warning,
+			label: __( 'Warning', 'hm-media-weight' ),
+		},
+		error: {
+			color: '#d63638',
+			backgroundColor: '#fcf0f1',
+			icon: closeSmall,
+			label: __( 'Over limit', 'hm-media-weight' ),
+		},
+	};
+
+	const currentStatus = statusConfig[ sizeStatus ];
+
+	// Filter previewEntries by image and video.
+	const imagePreviewEntries = previewEntries.filter( ( entry ) => entry.initiatorType === 'img' );
+	const videoPreviewEntries = previewEntries.filter( ( entry ) => entry.initiatorType === 'video' );
+
+	// Total the image and video sizes from the preview data.
+	const imagePreviewEntriesSize = imagePreviewEntries.reduce( ( total, entry ) => total + ( entry.previewSize || 0 ), 0 ) / MB_IN_B;
+	const videoPreviewEntriesSize = videoPreviewEntries.reduce( ( total, entry ) => total + ( entry.previewSize || 0 ), 0 ) / MB_IN_B;
+
+	// Platform options for SelectControl
+	const platformOptions = Object.entries( previewPlatforms ).map( ( [ key, { label } ] ) => ( {
+		value: key,
+		label,
+	} ) );
+
+	// Disable the button when fetching.
 	return (
 		<PluginSidebar className={ SIDEBAR_NAME } title={ __( 'Media Weight', 'hm-media-weight' ) }>
-			<PanelBody>
-				<Button
-					className="components-button is-compact is-secondary"
-					onClick={ () => {
-						insertIframe( iframeURL );
-					} }
-				>
-					{ __( 'Get Performance API Entries', 'hm-media-weight' ) }
-				</Button>
-			</PanelBody>
+			<PanelBody initialOpen={ true }>
+				<Flex direction="column" gap={ 4 }>
+					{ /* Total Media Weight Section */ }
+					{ /* Loading Skeleton */ }
+					{ isFetchingPreview && <MediaWeightSkeleton /> }
 
-			<PanelBody
-				initialOpen={ true }
-				title={ __( 'Total Media Items', 'hm-media-weight' ) }
-			>
-				<p>{ imageCount
-					? sprintf(
-						/* translators: %d: Number of WP-hosted images in post. */
-						__( 'Images: %d', 'hm-media-weight' ),
-						imageCount
-					)
-					: __( 'No images', 'hm-media-weight' )
-				}</p>
-				<p>{ videoCount
-					? sprintf(
-						/* translators: %d: Number of WP-hosted videos in post. */
-						__( 'Videos: %d', 'hm-media-weight' ),
-						videoCount
-					)
-					: __( 'No videos', 'hm-media-weight' )
-				}</p>
-
-				<DisplayTotal
-					imageCount={ imageCount }
-					imagesSize={ imagesSize }
-					videoCount={ videoCount }
-					videosSize={ videosSize }
-				/>
-			</PanelBody>
-
-			<PanelBody
-				initialOpen={ false }
-				title={ __( 'Individual Media Items', 'hm-media-weight' ) }
-			>
-				{ attachmentSizeDetails.map( ( { attachment, thumbnail, type, mediaSize, blockButton, requestedSize } ) => {
-
-					return (
-						<PanelRow key={ `media-details-${ attachment.id }` }>
-							<div>
-								{ thumbnail ? (
-									<img
-										src={ thumbnail }
-										alt=""
-										style={ { maxWidth: '100%' } }
+					{ /* Total Media Weight Section
+					The label will read "Mobile media weight" or "Desktop media weight" depending on the selected platform. */ }
+					{ ! isFetchingPreview && (
+						<div>
+							<p style={ { fontWeight: 600, marginBottom: '8px' } }>
+								{ mediaWeightHeader }
+							</p>
+							{ /* Status badge */ }
+							{ previewEntries.length > 0 ? (
+								<Flex
+									gap={ 2 }
+									align="center"
+									justify="center"
+									style={ {
+										backgroundColor: currentStatus.backgroundColor,
+										borderRadius: '4px',
+										padding: '8px 12px',
+										border: `1px solid ${ currentStatus.color }`,
+									} }
+								>
+									<Icon
+										icon={ currentStatus.icon }
+										style={ { fill: currentStatus.color, flexShrink: 0 } }
+										size={ 20 }
 									/>
-								) : null }
+									<span
+										style={ { fontWeight: 600, color: currentStatus.color, fontSize: '16px' } }
+									>
+										{ previewBytesTotal } MB
+									</span>
+									<span
+										style={ { color: currentStatus.color } }
+										aria-label={ sprintf(
+											/* translators: %s: Status label (Good, Warning, or Over limit). */
+											__( 'Status: %s', 'hm-media-weight' ),
+											currentStatus.label
+										) }
+									>
+										({ currentStatus.label })
+									</span>
+								</Flex>
+							) : (
+								<div className="components-text is-secondary">
+									{ __( 'No data yet. Click refresh to calculate.', 'hm-media-weight' ) }
+								</div>
+							) }
+						</div>
+					) }
 
-								<p>
-									<strong>
-										{ type }: {
-											( mediaSize < MB_IN_B )
-												? `${ ( mediaSize / KB_IN_B ).toFixed( 2 ) }kb`
-												: `${ ( mediaSize / MB_IN_B ).toFixed( 2 ) }mb`
-										}
-									</strong>
-								</p>
+					{ /* Media Breakdown Section */ }
+					{ ! isFetchingPreview && previewEntries.length > 0 && (
+						<Flex direction="column" gap={ 2 }>
+							<Flex gap={ 2 } align="center" justify="flex-start">
+								<Icon icon={ image } size={ 18 } style={ { opacity: 0.7, flexShrink: 0 } } />
+								<span>
+									{ imagePreviewEntries.length
+										? sprintf(
+												/* translators: %1$d: Number of images, %2$s: Size in MB. */
+												__( '%1$d images (%2$s MB)', 'hm-media-weight' ),
+												imagePreviewEntries.length,
+												imagePreviewEntriesSize.toFixed( 4 )
+										  )
+										: __( 'No images (0.00 MB)', 'hm-media-weight' )
+									}
+								</span>
+							</Flex>
+							<Flex gap={ 2 } align="center" justify="flex-start">
+								<Icon icon={ video } size={ 18 } style={ { opacity: 0.7, flexShrink: 0 } } />
+								<span>
+									{ videoPreviewEntries.length
+										? sprintf(
+												/* translators: %1$d: Number of videos, %2$s: Size in MB. */
+												__( '%1$d videos (%2$s MB)', 'hm-media-weight' ),
+												videoPreviewEntries.length,
+												videoPreviewEntriesSize.toFixed( 4 )
+										  )
+										: __( 'No videos (0.00 MB)', 'hm-media-weight' )
+									}
+								</span>
+							</Flex>
+						</Flex>
+					) }
 
-								<p>
-									Attachment ID: { attachment.id }<br />
-									<small><a href={ `upload.php?item=${ attachment.id }` }>Go to the attachment post &rsaquo;</a></small>
-								</p>
+					{ /* Warning Notice */ }
+					{ ! isFetchingPreview && sizeStatus === 'error' && (
+						<Notice
+							status="error"
+							isDismissible={ false }
+						>
+							{ sprintf(
+								/* translators: %s: Maximum allowed size (in megabytes) for all media on page. */
+								__( 'Media weight exceeds the recommended threshold of %s MB. Consider optimizing your images or using smaller file sizes.', 'hm-media-weight' ),
+								mediaThreshold
+							) }
+						</Notice>
+					) }
 
-								{ requestedSize === 'full' && (
-									<>
-										<Flex direction="row" align="flex-start" gap={ 6 }>
-											<FlexItem>
-												<Icon icon={ caution } size={ 36 } />
-											</FlexItem>
-											<FlexItem>
-												<p><strong>{ __( 'Full size image requested. Edit block to request smaller image.', 'hm-media-weight' ) }</strong></p>
-											</FlexItem>
-										</Flex>
-									</>
-								) }
+					{ /* Warning for approaching limit */ }
+					{ ! isFetchingPreview && sizeStatus === 'warning' && (
+						<Notice
+							status="warning"
+							isDismissible={ false }
+						>
+							{ sprintf(
+								/* translators: %s: Maximum allowed size (in megabytes) for all media on page. */
+								__( 'Media weight is approaching the recommended threshold of %s MB.', 'hm-media-weight' ),
+								mediaThreshold
+							) }
+						</Notice>
+					) }
 
-								<details style={ { display: 'none', margin: '0.5rem 0 1rem' } }>
-									<summary>{ __( 'View entity record JSON', 'hm-media-weight' ) }</summary>
-									<small>
-										<pre>
-											{ JSON.stringify( attachment, null, 2 ) }
-										</pre>
-									</small>
-								</details>
+					{ /* Platform Selection */ }
+					<SelectControl
+						label={ __( 'Preview platform', 'hm-media-weight' ) }
+						value={ previewPlatform }
+						options={ platformOptions }
+						onChange={ setPreviewPlatform }
+						help={ sprintf(
+							/* translators: %s: Preview mode (mobile or desktop). */
+							__( 'Media weight reflects all media loaded on a %s viewport.', 'hm-media-weight' ),
+							previewPlatforms[ previewPlatform ].label
+						) }
+						__nextHasNoMarginBottom
+					/>
 
-								{ blockButton }
-								<hr />
-							</div>
-						</PanelRow>
-					);
-				} ) }
+					{ /* Refresh Button */ }
+					<Button
+						variant="secondary"
+						onClick={ () => insertPreviewIframe( iframeURL, previewPlatform ) }
+						disabled={ isFetchingPreview }
+						aria-label={ __( 'Refresh preview data to recalculate media weight', 'hm-media-weight' ) }
+					>
+						{ __( 'Refresh Preview Data', 'hm-media-weight' ) }
+					</Button>
+				</Flex>
 			</PanelBody>
 		</PluginSidebar>
 	);

--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,7 @@ import { addQueryArgs } from '@wordpress/url';
 import { ReactComponent as ScalesIcon } from './assets/scale-icon.svg';
 
 // Media size threshold (in MB) from server configuration.
-const { mediaThreshold } = window.mediaWeightData;
+const { mediaThreshold } = window.mediaWeightData || { mediaThreshold: 2.5 };
 
 // Plugin and sidebar identifiers.
 const PLUGIN_NAME = 'hm-media-weight';
@@ -179,6 +179,9 @@ const HMMediaWeightSidebar = () => {
 
 	// Refresh the preview iframe when URL or platform changes.
 	useEffect( () => {
+		if ( ! iframeURL ) {
+			return;
+		}
 		setPreviewEntries( [] );
 		insertPreviewIframe( iframeURL, previewPlatform );
 	}, [ iframeURL, insertPreviewIframe, previewPlatform ] );
@@ -186,6 +189,11 @@ const HMMediaWeightSidebar = () => {
 	// Listens for postMessage from the preview iframe containing Performance API resource data.
 	useEffect( () => {
 		const listener = ( event ) => {
+			// Only accept messages from same origin.
+			if ( event.origin !== window.location.origin ) {
+				return;
+			}
+
 			let receivedEntries = event.data;
 
 			try {

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress editor plugin for calculating and displaying page media weight.
  */
-import { useMemo, useState, useCallback } from 'react';
+import { useState, useCallback } from 'react';
 import { __, sprintf } from '@wordpress/i18n';
 import { PluginSidebar } from '@wordpress/editor';
 import {
@@ -15,8 +15,6 @@ import {
 import { registerPlugin, unregisterPlugin } from '@wordpress/plugins';
 import { useSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
-import { store as blockEditorStore } from '@wordpress/block-editor';
-import { useEntityRecords } from '@wordpress/core-data';
 import { check, warning, closeSmall, image, video } from '@wordpress/icons';
 import { addQueryArgs } from '@wordpress/url';
 

--- a/src/index.js
+++ b/src/index.js
@@ -65,65 +65,8 @@ const SkeletonBox = ( { width = '100%', height = '16px', style = {} } ) => (
 	/>
 );
 
-// Recursively extracts image and video blocks from the editor block tree.
-const getMediaBlocks = ( blocks ) => blocks.reduce(
-	( mediaBlocks, block ) => {
-		if ( [ 'core/image', 'core/video' ].includes( block.name ) ) {
-			mediaBlocks.push( block );
-		}
-		if ( block.innerBlocks ) {
-			return mediaBlocks.concat( getMediaBlocks( block.innerBlocks ) );
-		}
-		return mediaBlocks;
-	},
-	[]
-);
-
-// Custom hook that retrieves media block IDs and fetches their attachment records.
-const useMediaBlocks = () => {
-	const mediaBlocks = useSelect( ( select ) => getMediaBlocks( select( blockEditorStore ).getBlocks() ) );
-	const featuredImageId = useSelect( ( select ) => select( 'core/editor' ).getEditedPostAttribute( 'featured_media' ) );
-
-	/* eslint-disable no-shadow */
-	const { imageIds, videoIds } = useMemo( () => {
-		const imageIds = [];
-		const videoIds = [];
-		for ( const block of mediaBlocks ) {
-			if ( ! block.attributes?.id ) {
-				continue;
-			}
-			if ( block.name === 'core/image' ) {
-				imageIds.push( block.attributes.id );
-			} else if ( block.name === 'core/video' ) {
-				videoIds.push( block.attributes.id );
-			}
-		}
-		if ( featuredImageId !== 0 ) {
-			imageIds.push( featuredImageId );
-		}
-		return { imageIds, videoIds };
-	}, [ mediaBlocks, featuredImageId ] );
-	/* eslint-enable no-shadow */
-
-	const imageRecords = useEntityRecords( 'postType', 'attachment', {
-		per_page: imageIds.length,
-		include: imageIds,
-	} )?.records || [];
-	const videoRecords = useEntityRecords( 'postType', 'attachment', {
-		per_page: videoIds.length,
-		include: videoIds,
-	} )?.records || [];
-
-	return {
-		attachments: imageRecords.concat( videoRecords ),
-	};
-};
-
 // Main sidebar component that displays media weight calculations and status.
 const HMMediaWeightSidebar = () => {
-	const {
-		attachments,
-	} = useMediaBlocks();
 
 	// Performance API (“preview”) entries state.
 	const [ previewEntries, setPreviewEntries ] = useState( [] );
@@ -310,7 +253,7 @@ const HMMediaWeightSidebar = () => {
 		return () => {
 			window.removeEventListener( 'message', listener );
 		};
-	}, [ attachments ] );
+	}, [] );
 
 	// Calculate total media weight and determine status level.
 	let previewBytesTotal = previewEntries.reduce( ( total, entry ) => total + ( entry.previewSize || 0 ), 0 );

--- a/src/index.js
+++ b/src/index.js
@@ -232,6 +232,7 @@ const HMMediaWeightSidebar = () => {
 	useEffect( () => {
 		window.addEventListener( 'message', ( event ) => {
 			const receivedEntries = event.data;
+			// eslint-disable-next-line no-console
 			console.log( receivedEntries );
 		} );
 	}, [ iframeURL ] );

--- a/src/index.js
+++ b/src/index.js
@@ -9,10 +9,11 @@ import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as editPostStore } from '@wordpress/edit-post';
 import { useEntityRecords } from '@wordpress/core-data';
 import { Icon, caution } from '@wordpress/icons';
+import { addQueryArgs } from '@wordpress/url';
 
 import { ReactComponent as ScalesIcon } from './assets/scale-icon.svg';
 
-const { mediaThreshold, featuredImageSize, previewPostLink } = window.mediaWeightData;
+const { mediaThreshold, featuredImageSize } = window.mediaWeightData;
 
 const PLUGIN_NAME = 'hm-media-weight';
 const SIDEBAR_NAME = PLUGIN_NAME;
@@ -196,9 +197,12 @@ const HMMediaWeightSidebar = () => {
 	} );
 
 	const insertIframe = ( url, width = '1600px', height = '800px' ) => {
-		const iframeExists = document.getElementById( 'post-preview-iframe' );
+		const iframeWindow = document.getElementById( 'post-preview-iframe' );
 
-		if ( ! iframeExists ) {
+		if ( iframeWindow ) {
+			// Reload the iframe to recalculate performance entries.
+			iframeWindow.contentWindow.location.reload();
+		} else {
 			const iframe = document.createElement( 'iframe' );
 			iframe.src = url;
 			iframe.width = width;
@@ -209,33 +213,21 @@ const HMMediaWeightSidebar = () => {
 		}
 	}
 
-	const addQueryString = ( url, params ) => {
-		const urlObject = new URL( url );
-		const searchParams = new URLSearchParams( urlObject.search );
-
-		for ( const key in params ) {
-			if ( params.hasOwnProperty( key ) ) {
-				searchParams.set( key, params[key] );
-			}
-		}
-
-		urlObject.search = searchParams.toString();
-
-		return urlObject.toString();
-	}
-
-	const newParams = {
-		mediaWeight: '1'
-	};
-	const iframeURL = addQueryString( previewPostLink, newParams );
+	const previewPostLink = useSelect( ( select ) => select( 'core/editor' ).getEditedPostPreviewLink() );
+	const iframeURL = addQueryArgs( previewPostLink, { mediaWeight: '1' } );
 
 	useEffect( () => {
-		window.addEventListener( 'message', ( event ) => {
+		const listener = window.addEventListener( 'message', ( event ) => {
 			const receivedEntries = event.data;
 			// eslint-disable-next-line no-console
 			console.log( receivedEntries );
+			// You can call a useState callback here to get the data into the component.
 		} );
-	}, [ iframeURL ] );
+
+		return () => {
+			window.removeEventListener( listener );
+		};
+	}, [] );
 
 	return (
 		<PluginSidebar className={ SIDEBAR_NAME } title={ __( 'Media Weight', 'hm-media-weight' ) }>

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import { PluginSidebar } from '@wordpress/editor';
 import { PanelRow, PanelBody, Button, FlexItem, Flex } from '@wordpress/components';
 import { registerPlugin, unregisterPlugin } from '@wordpress/plugins';
 import { useDispatch, useSelect } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as editPostStore } from '@wordpress/edit-post';
 import { useEntityRecords } from '@wordpress/core-data';
@@ -11,7 +12,7 @@ import { Icon, caution } from '@wordpress/icons';
 
 import { ReactComponent as ScalesIcon } from './assets/scale-icon.svg';
 
-const { mediaThreshold, featuredImageSize } = window.mediaWeightData;
+const { mediaThreshold, featuredImageSize, previewPostLink } = window.mediaWeightData;
 
 const PLUGIN_NAME = 'hm-media-weight';
 const SIDEBAR_NAME = PLUGIN_NAME;
@@ -194,8 +195,60 @@ const HMMediaWeightSidebar = () => {
 		};
 	} );
 
+	const insertIframe = ( url, width = '1600px', height = '800px' ) => {
+		const iframeExists = document.getElementById( 'post-preview-iframe' );
+
+		if ( ! iframeExists ) {
+			const iframe = document.createElement( 'iframe' );
+			iframe.src = url;
+			iframe.width = width;
+			iframe.height = height;
+			iframe.id = 'post-preview-iframe';
+			iframe.style.display = 'none';
+			document.body.appendChild( iframe );
+		}
+	}
+
+	const addQueryString = ( url, params ) => {
+		const urlObject = new URL( url );
+		const searchParams = new URLSearchParams( urlObject.search );
+
+		for ( const key in params ) {
+			if ( params.hasOwnProperty( key ) ) {
+				searchParams.set( key, params[key] );
+			}
+		}
+
+		urlObject.search = searchParams.toString();
+
+		return urlObject.toString();
+	}
+
+	const newParams = {
+		mediaWeight: '1'
+	};
+	const iframeURL = addQueryString( previewPostLink, newParams );
+
+	useEffect( () => {
+		window.addEventListener( 'message', ( event ) => {
+			const receivedEntries = event.data;
+			console.log( receivedEntries );
+		} );
+	}, [ iframeURL ] );
+
 	return (
 		<PluginSidebar className={ SIDEBAR_NAME } title={ __( 'Media Weight', 'hm-media-weight' ) }>
+			<PanelBody>
+				<Button
+					className="components-button is-compact is-secondary"
+					onClick={ () => {
+						insertIframe( iframeURL );
+					} }
+				>
+					{ __( 'Get Performance API Entries', 'hm-media-weight' ) }
+				</Button>
+			</PanelBody>
+
 			<PanelBody
 				initialOpen={ true }
 				title={ __( 'Total Media Items', 'hm-media-weight' ) }

--- a/src/index.js
+++ b/src/index.js
@@ -46,7 +46,7 @@ const previewPlatforms = {
 	},
 };
 
-// Animated skeleton loading placeholder with shimmer effect.
+// Animated skeleton loading placeholder with shimmer effect. @keyframes shimmer added to admin footer separately.
 const SkeletonBox = ( { width = '100%', height = '16px', style = {} } ) => (
 	<div
 		aria-hidden="true"
@@ -182,6 +182,9 @@ const HMMediaWeightSidebar = () => {
 		}
 		setPreviewEntries( [] );
 		insertPreviewIframe( iframeURL, previewPlatform );
+		return () => {
+			removePreviewIframe();
+		};
 	}, [ iframeURL, insertPreviewIframe, previewPlatform ] );
 
 	// Listens for postMessage from the preview iframe containing Performance API resource data.

--- a/src/index.js
+++ b/src/index.js
@@ -217,17 +217,46 @@ const HMMediaWeightSidebar = () => {
 	const iframeURL = addQueryArgs( previewPostLink, { mediaWeight: '1' } );
 
 	useEffect( () => {
-		const listener = window.addEventListener( 'message', ( event ) => {
-			const receivedEntries = event.data;
+		const listener = ( event ) => {
+			let receivedEntries = event.data;
+			let mediaEntries = {};
+
+			receivedEntries = JSON.parse( receivedEntries );
+
+			// Select only images and videos.
+			const filteredEntries = receivedEntries.filter( ( entry ) => {
+				return entry.initiatorType === 'img' || entry.initiatorType === 'video';
+			} );
+
+			filteredEntries.forEach( ( entry, index ) => {
+				let mediaID;
+
+				for ( const attachment of attachments ) {
+					if ( ! entry.name.includes( attachment.generated_slug ) ) {
+						continue;
+					}
+
+					mediaID = attachment.id;
+				};
+
+				mediaEntries[index] = {
+					mediaID: mediaID ? mediaID : null,
+					mediaSize: entry.encodedBodySize,
+					mediaType: entry.initiatorType,
+					mediaURL: entry.name,
+				};
+			} );
+
 			// eslint-disable-next-line no-console
-			console.log( receivedEntries );
-			// You can call a useState callback here to get the data into the component.
-		} );
+			console.log( mediaEntries );
+		}
+
+		window.addEventListener( 'message', listener );
 
 		return () => {
-			window.removeEventListener( listener );
+			window.removeEventListener( 'message', listener );
 		};
-	}, [] );
+	}, [ attachments ] );
 
 	return (
 		<PluginSidebar className={ SIDEBAR_NAME } title={ __( 'Media Weight', 'hm-media-weight' ) }>

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { __, sprintf } from '@wordpress/i18n';
-import { PluginSidebar, PluginSidebarMoreMenuItem } from '@wordpress/editor';
+import { PluginSidebar } from '@wordpress/editor';
 import { PanelRow, PanelBody, Button, FlexItem, Flex } from '@wordpress/components';
 import { registerPlugin, unregisterPlugin } from '@wordpress/plugins';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -195,103 +195,98 @@ const HMMediaWeightSidebar = () => {
 	} );
 
 	return (
-		<>
-			<PluginSidebarMoreMenuItem target={ SIDEBAR_NAME }>
-				{ __( 'Media Weight sidebar', 'hm-media-weight' ) }
-			</PluginSidebarMoreMenuItem>
-			<PluginSidebar className={ SIDEBAR_NAME } name={ SIDEBAR_NAME } title={ __( 'Media Weight', 'hm-media-weight' ) }>
-				<PanelBody
-					initialOpen={ true }
-					title={ __( 'Total Media Items', 'hm-media-weight' ) }
-				>
-					<p>{ imageCount
-						? sprintf(
-							/* translators: %d: Number of WP-hosted images in post. */
-							__( 'Images: %d', 'hm-media-weight' ),
-							imageCount
-						)
-						: __( 'No images', 'hm-media-weight' )
-					}</p>
-					<p>{ videoCount
-						? sprintf(
-							/* translators: %d: Number of WP-hosted videos in post. */
-							__( 'Videos: %d', 'hm-media-weight' ),
-							videoCount
-						)
-						: __( 'No videos', 'hm-media-weight' )
-					}</p>
+		<PluginSidebar className={ SIDEBAR_NAME } title={ __( 'Media Weight', 'hm-media-weight' ) }>
+			<PanelBody
+				initialOpen={ true }
+				title={ __( 'Total Media Items', 'hm-media-weight' ) }
+			>
+				<p>{ imageCount
+					? sprintf(
+						/* translators: %d: Number of WP-hosted images in post. */
+						__( 'Images: %d', 'hm-media-weight' ),
+						imageCount
+					)
+					: __( 'No images', 'hm-media-weight' )
+				}</p>
+				<p>{ videoCount
+					? sprintf(
+						/* translators: %d: Number of WP-hosted videos in post. */
+						__( 'Videos: %d', 'hm-media-weight' ),
+						videoCount
+					)
+					: __( 'No videos', 'hm-media-weight' )
+				}</p>
 
-					<DisplayTotal
-						imageCount={ imageCount }
-						imagesSize={ imagesSize }
-						videoCount={ videoCount }
-						videosSize={ videosSize }
-					/>
-				</PanelBody>
+				<DisplayTotal
+					imageCount={ imageCount }
+					imagesSize={ imagesSize }
+					videoCount={ videoCount }
+					videosSize={ videosSize }
+				/>
+			</PanelBody>
 
-				<PanelBody
-					initialOpen={ false }
-					title={ __( 'Individual Media Items', 'hm-media-weight' ) }
-				>
-					{ attachmentSizeDetails.map( ( { attachment, thumbnail, type, mediaSize, blockButton, requestedSize } ) => {
+			<PanelBody
+				initialOpen={ false }
+				title={ __( 'Individual Media Items', 'hm-media-weight' ) }
+			>
+				{ attachmentSizeDetails.map( ( { attachment, thumbnail, type, mediaSize, blockButton, requestedSize } ) => {
 
-						return (
-							<PanelRow key={ `media-details-${ attachment.id }` }>
-								<div>
-									{ thumbnail ? (
-										<img
-											src={ thumbnail }
-											alt=""
-											style={ { maxWidth: '100%' } }
-										/>
-									) : null }
+					return (
+						<PanelRow key={ `media-details-${ attachment.id }` }>
+							<div>
+								{ thumbnail ? (
+									<img
+										src={ thumbnail }
+										alt=""
+										style={ { maxWidth: '100%' } }
+									/>
+								) : null }
 
-									<p>
-										<strong>
-											{ type }: {
-												( mediaSize < MB_IN_B )
-													? `${ ( mediaSize / KB_IN_B ).toFixed( 2 ) }kb`
-													: `${ ( mediaSize / MB_IN_B ).toFixed( 2 ) }mb`
-											}
-										</strong>
-									</p>
+								<p>
+									<strong>
+										{ type }: {
+											( mediaSize < MB_IN_B )
+												? `${ ( mediaSize / KB_IN_B ).toFixed( 2 ) }kb`
+												: `${ ( mediaSize / MB_IN_B ).toFixed( 2 ) }mb`
+										}
+									</strong>
+								</p>
 
-									<p>
-										Attachment ID: { attachment.id }<br />
-										<small><a href={ `upload.php?item=${ attachment.id }` }>Go to the attachment post &rsaquo;</a></small>
-									</p>
+								<p>
+									Attachment ID: { attachment.id }<br />
+									<small><a href={ `upload.php?item=${ attachment.id }` }>Go to the attachment post &rsaquo;</a></small>
+								</p>
 
-									{ requestedSize === 'full' && (
-										<>
-											<Flex direction="row" align="flex-start" gap={ 6 }>
-												<FlexItem>
-													<Icon icon={ caution } size={ 36 } />
-												</FlexItem>
-												<FlexItem>
-													<p><strong>{ __( 'Full size image requested. Edit block to request smaller image.', 'hm-media-weight' ) }</strong></p>
-												</FlexItem>
-											</Flex>
-										</>
-									) }
+								{ requestedSize === 'full' && (
+									<>
+										<Flex direction="row" align="flex-start" gap={ 6 }>
+											<FlexItem>
+												<Icon icon={ caution } size={ 36 } />
+											</FlexItem>
+											<FlexItem>
+												<p><strong>{ __( 'Full size image requested. Edit block to request smaller image.', 'hm-media-weight' ) }</strong></p>
+											</FlexItem>
+										</Flex>
+									</>
+								) }
 
-									<details style={ { display: 'none', margin: '0.5rem 0 1rem' } }>
-										<summary>{ __( 'View entity record JSON', 'hm-media-weight' ) }</summary>
-										<small>
-											<pre>
-												{ JSON.stringify( attachment, null, 2 ) }
-											</pre>
-										</small>
-									</details>
+								<details style={ { display: 'none', margin: '0.5rem 0 1rem' } }>
+									<summary>{ __( 'View entity record JSON', 'hm-media-weight' ) }</summary>
+									<small>
+										<pre>
+											{ JSON.stringify( attachment, null, 2 ) }
+										</pre>
+									</small>
+								</details>
 
-									{ blockButton }
-									<hr />
-								</div>
-							</PanelRow>
-						);
-					} ) }
-				</PanelBody>
-			</PluginSidebar>
-		</>
+								{ blockButton }
+								<hr />
+							</div>
+						</PanelRow>
+					);
+				} ) }
+			</PanelBody>
+		</PluginSidebar>
 	);
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -219,7 +219,7 @@ const HMMediaWeightSidebar = () => {
 	useEffect( () => {
 		const listener = ( event ) => {
 			let receivedEntries = event.data;
-			let mediaEntries = {};
+			const mediaEntries = {};
 
 			receivedEntries = JSON.parse( receivedEntries );
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,6 @@
+/**
+ * WordPress editor plugin for calculating and displaying page media weight.
+ */
 import { useMemo, useState, useCallback } from 'react';
 import { __, sprintf } from '@wordpress/i18n';
 import { PluginSidebar } from '@wordpress/editor';
@@ -19,12 +22,17 @@ import { addQueryArgs } from '@wordpress/url';
 
 import { ReactComponent as ScalesIcon } from './assets/scale-icon.svg';
 
+// Media size threshold (in MB) from server configuration.
 const { mediaThreshold } = window.mediaWeightData;
 
+// Plugin and sidebar identifiers.
 const PLUGIN_NAME = 'hm-media-weight';
 const SIDEBAR_NAME = PLUGIN_NAME;
+
+// Bytes per megabyte conversion constant.
 const MB_IN_B = 1024 * 1024;
 
+// Viewport configurations for mobile and desktop preview modes.
 const previewPlatforms = {
 	mobile: {
 		label: __( 'Mobile', 'hm-media-weight' ),
@@ -40,7 +48,7 @@ const previewPlatforms = {
 	},
 };
 
-// Skeleton loading placeholder component.
+// Animated skeleton loading placeholder with shimmer effect.
 const SkeletonBox = ( { width = '100%', height = '16px', style = {} } ) => (
 	<div
 		aria-hidden="true"
@@ -57,6 +65,7 @@ const SkeletonBox = ( { width = '100%', height = '16px', style = {} } ) => (
 	/>
 );
 
+// Recursively extracts image and video blocks from the editor block tree.
 const getMediaBlocks = ( blocks ) => blocks.reduce(
 	( mediaBlocks, block ) => {
 		if ( [ 'core/image', 'core/video' ].includes( block.name ) ) {
@@ -70,6 +79,7 @@ const getMediaBlocks = ( blocks ) => blocks.reduce(
 	[]
 );
 
+// Custom hook that retrieves media block IDs and fetches their attachment records.
 const useMediaBlocks = () => {
 	const mediaBlocks = useSelect( ( select ) => getMediaBlocks( select( blockEditorStore ).getBlocks() ) );
 	const featuredImageId = useSelect( ( select ) => select( 'core/editor' ).getEditedPostAttribute( 'featured_media' ) );
@@ -109,6 +119,7 @@ const useMediaBlocks = () => {
 	};
 };
 
+// Main sidebar component that displays media weight calculations and status.
 const HMMediaWeightSidebar = () => {
 	const {
 		attachments,
@@ -132,7 +143,7 @@ const HMMediaWeightSidebar = () => {
 			previewPlatforms[ previewPlatform ].label
 		);
 
-	// Skeleton loader to mimic the loaded state layout.
+	// Skeleton loader component that mimics the loaded state layout.
 	const MediaWeightSkeleton = () => (
 		<Flex direction="column" gap={ 4 } aria-label={ __( 'Loading media weight data…', 'hm-media-weight' ) }>
 			<div>
@@ -182,6 +193,7 @@ const HMMediaWeightSidebar = () => {
 		);
 	}, [ previewPostLink, previewPlatform ] );
 
+	// Removes the preview iframe from the DOM.
 	const removePreviewIframe = () => {
 		const iframeToRemove = document.getElementById( 'post-preview-iframe' );
 		if ( iframeToRemove ) {
@@ -189,6 +201,7 @@ const HMMediaWeightSidebar = () => {
 		}
 	};
 
+	// Creates and inserts a hidden iframe to load the post preview at the specified viewport size.
 	const insertPreviewIframe = useCallback( ( url, platform = 'mobile' ) => {
 		const { width, height } = previewPlatforms[ platform ];
 		setIsFetchingPreview( true );
@@ -221,37 +234,13 @@ const HMMediaWeightSidebar = () => {
 		document.body.appendChild( iframe );
 	}, [] );
 
+	// Refresh the preview iframe when URL or platform changes.
 	useEffect( () => {
-		if ( ! iframeURL ) {
-			return;
-		}
-
-		// Only trigger once the plugin sidebar is actually in the DOM (i.e. opened).
-		const sidebarSelector = `.${ SIDEBAR_NAME }`;
-		let tries = 0;
-		const maxTries = 50; // ~5s at 100ms
-
-		const intervalId = window.setInterval( () => {
-			tries++;
-			const sidebarIsOpen = Boolean( document.querySelector( sidebarSelector ) );
-
-			if ( ! sidebarIsOpen ) {
-				if ( tries >= maxTries ) {
-					window.clearInterval( intervalId );
-				}
-				return;
-			}
-
-			window.clearInterval( intervalId );
-			setPreviewEntries( [] );
-			insertPreviewIframe( iframeURL, previewPlatform );
-		}, 100 );
-
-		return () => {
-			window.clearInterval( intervalId );
-		};
+		setPreviewEntries( [] );
+		insertPreviewIframe( iframeURL, previewPlatform );
 	}, [ iframeURL, insertPreviewIframe, previewPlatform ] );
 
+	// Listens for postMessage from the preview iframe containing Performance API resource data.
 	useEffect( () => {
 		const listener = ( event ) => {
 			let receivedEntries = event.data;
@@ -323,11 +312,12 @@ const HMMediaWeightSidebar = () => {
 		};
 	}, [ attachments ] );
 
+	// Calculate total media weight and determine status level.
 	let previewBytesTotal = previewEntries.reduce( ( total, entry ) => total + ( entry.previewSize || 0 ), 0 );
 
 	previewBytesTotal = ( previewBytesTotal / MB_IN_B ).toFixed( 2 );
 
-	// Determine status level for accessibility (not just color)
+	// Determine status level for accessibility (not just color).
 	let sizeStatus;
 	if ( previewBytesTotal >= 0 && previewBytesTotal <= ( mediaThreshold / 2 ) ) {
 		sizeStatus = 'good';
@@ -337,7 +327,7 @@ const HMMediaWeightSidebar = () => {
 		sizeStatus = 'error';
 	}
 
-	// Status configuration for colors, icons, and labels
+	// Status configuration mapping for visual indicators.
 	const statusConfig = {
 		good: {
 			color: '#00a32a',
@@ -525,12 +515,13 @@ const HMMediaWeightSidebar = () => {
 	);
 };
 
+// Registers the Media Weight plugin sidebar with WordPress.
 registerPlugin( PLUGIN_NAME, {
 	icon: ScalesIcon,
 	render: HMMediaWeightSidebar,
 } );
 
-// Block HMR boilerplate.
+// Hot Module Replacement support for development.
 if ( module.hot ) {
 	module.hot.accept();
 	module.hot.dispose( () => unregisterPlugin( PLUGIN_NAME ) );

--- a/src/index.js
+++ b/src/index.js
@@ -316,15 +316,12 @@ const HMMediaWeightSidebar = () => {
 					{ /* Total Media Weight Section */ }
 					{ /* Loading Skeleton */ }
 					{ isFetchingPreview && <MediaWeightSkeleton /> }
-
-					{ /* Total Media Weight Section
-					The label will read "Mobile media weight" or "Desktop media weight" depending on the selected platform. */ }
+					{ /* Total Media Weight Section */ }
 					{ ! isFetchingPreview && (
 						<div>
 							<p style={ { fontWeight: 600, marginBottom: '8px' } }>
 								{ mediaWeightHeader }
 							</p>
-							{ /* Status badge */ }
 							{ previewEntries.length > 0 ? (
 								<Flex
 									gap={ 2 }
@@ -365,7 +362,6 @@ const HMMediaWeightSidebar = () => {
 							) }
 						</div>
 					) }
-
 					{ /* Media Breakdown Section */ }
 					{ ! isFetchingPreview && previewEntries.length > 0 && (
 						<Flex direction="column" gap={ 2 }>
@@ -399,7 +395,6 @@ const HMMediaWeightSidebar = () => {
 							</Flex>
 						</Flex>
 					) }
-
 					{ /* Warning Notice */ }
 					{ ! isFetchingPreview && sizeStatus === 'error' && (
 						<Notice
@@ -413,7 +408,6 @@ const HMMediaWeightSidebar = () => {
 							) }
 						</Notice>
 					) }
-
 					{ /* Warning for approaching limit */ }
 					{ ! isFetchingPreview && sizeStatus === 'warning' && (
 						<Notice
@@ -427,7 +421,6 @@ const HMMediaWeightSidebar = () => {
 							) }
 						</Notice>
 					) }
-
 					{ /* Platform Selection */ }
 					<SelectControl
 						label={ __( 'Preview platform', 'hm-media-weight' ) }
@@ -441,7 +434,6 @@ const HMMediaWeightSidebar = () => {
 						) }
 						__nextHasNoMarginBottom
 					/>
-
 					{ /* Refresh Button */ }
 					<Button
 						variant="secondary"


### PR DESCRIPTION
## Description
Updated implementation of media-weight collection, based on the work @roborourke started, using [performance.getEntriesByType](https://developer.mozilla.org/en-US/docs/Web/API/Performance/getEntriesByType)- part of the [Performance API](https://developer.mozilla.org/en-US/docs/Web/API/Performance) which reports on the weight (size) of assets. Sizes are typically only reported for same domain assets, which meets our requirements neatly.

This PR supersedes https://github.com/humanmade/media-weight/pull/12

## Overall approach
 * An iframe containing a preview of the post is injected offscreen. The preview is customized in part to capture metrics using `performance.getEntriesByType` and send them out to the iframe parent - the editor.
 * A toggle allows measuring asset Mobile or Desktop media sizes
 * A total amount is calculated, with breakdowns for images and video
 * Duplicates are discarded
 * Only same origin assets are counted
 * Video autoplay is disabled, only the poster image bandwidth is reported

## Screencast
https://github.com/user-attachments/assets/5d184a62-247d-460a-9716-d9ee107f3bb3

## Testing instructions
* Create a post 
* Open the media weight sidebar
* Upload several images and videos
* Check mobile or desktop weights at various points
* Verify the total changes with each saved change
* Try changing image sizes and noting changes
* Verify Desktop is heavier than mobile
* Verify notices show as you approach the 2.5 threshold
